### PR TITLE
Style&Hotfix: 페이지 로딩 상태 처리 - 2 및 수정 사항 적용

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -7,7 +7,7 @@ import { endpoints } from './endpoints';
 
 const apiClient = (() =>
   axios.create({
-    baseURL: import.meta.env.DEV ? '' : import.meta.env.VITE_API_BASE_URL,
+    baseURL: import.meta.env.VITE_API_BASE_URL,
     headers: {
       'Content-Type': 'application/json',
     },

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -7,7 +7,7 @@ import { endpoints } from './endpoints';
 
 const apiClient = (() =>
   axios.create({
-    baseURL: import.meta.env.VITE_API_BASE_URL,
+    baseURL: import.meta.env.DEV ? '' : import.meta.env.VITE_API_BASE_URL,
     headers: {
       'Content-Type': 'application/json',
     },

--- a/src/components/input/SelectBox.tsx
+++ b/src/components/input/SelectBox.tsx
@@ -5,6 +5,7 @@ import { clsx } from 'clsx';
 import { IncomeExpenseType } from '@/types/transactionTypes';
 import { SelectOptionsType } from '@/types/fieldType';
 import { ReportType } from '@/types/reportTypes';
+import { FieldError, FieldErrorsImpl, Merge } from 'react-hook-form';
 
 interface SelectBoxProps {
   label?: string;
@@ -14,10 +15,12 @@ interface SelectBoxProps {
   type?: IncomeExpenseType;
   hasEditButton?: boolean;
   onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
+  errorMessage?: string | FieldError | Merge<FieldError, FieldErrorsImpl<any>> | undefined;
+  'data-testid'?: string;
 }
 
 const SelectBox = forwardRef<HTMLSelectElement, SelectBoxProps>(
-  ({ label, isRequired, options, value, type, hasEditButton, onChange, ...rest }, ref) => {
+  ({ label, isRequired, options, value, type, hasEditButton, onChange, errorMessage, ...rest }, ref) => {
     return (
       <div>
         <label className={`w-full flex ${label && 'justify-between'} items-center`}>
@@ -31,7 +34,7 @@ const SelectBox = forwardRef<HTMLSelectElement, SelectBoxProps>(
           <div className="w-3/5 relative">
             <div className="w-full h-[3.2rem] flex gap-2 cursor-pointer">
               <select
-                className="input-common appearance-none cursor-pointer"
+                className={clsx(errorMessage && 'border-sunsetRose!', 'input-common appearance-none cursor-pointer')}
                 {...rest}
                 value={value}
                 ref={ref}
@@ -45,12 +48,20 @@ const SelectBox = forwardRef<HTMLSelectElement, SelectBoxProps>(
               <span
                 className={clsx(
                   hasEditButton ? 'right-[4rem]' : 'right-[0.75rem]',
-                  'absolute top-1/2 -translate-y-1/2 pointer-events-none',
+                  'absolute pointer-events-none',
+                  errorMessage ? 'top-1/4 -translate-y-1/4' : 'top-1/2 -translate-y-1/2 ',
                 )}>
                 <DropdownIcon />
               </span>
               {hasEditButton && type && <CategoryLinkButton type={type} />}
             </div>
+            {typeof errorMessage === 'string' && errorMessage && (
+              <p
+                data-testid={rest['data-testid'] ? `${rest['data-testid']}-helper-text` : 'helper-text'}
+                className={clsx(errorMessage && 'text-sunsetRose', 'w-fit h-fit text-sm mt-1.5 whitespace-pre-line')}>
+                {errorMessage}
+              </p>
+            )}
           </div>
         </label>
       </div>

--- a/src/components/input/auth/PasswordField.tsx
+++ b/src/components/input/auth/PasswordField.tsx
@@ -1,11 +1,24 @@
 import PrimaryInput from '@/components/input/PrimaryInput';
+import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 const PasswordField = () => {
   const {
+    watch,
+    trigger,
     register,
     formState: { errors },
   } = useFormContext();
+
+  useEffect(() => {
+    const subscription = watch((_, { name }) => {
+      if (name === 'password') {
+        trigger(['passwordConfirm']);
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, [watch, trigger]);
 
   return (
     <>

--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -1,5 +1,7 @@
 import { SettingOptionType } from '@/types/types';
 
+export const LOADING_OPTIONS = [{ label: '불러오는 중..', value: '불러오는 중..' }];
+
 export const GENDER_OPTIONS = [
   { label: '여자', value: 'FEMALE' },
   { label: '남자', value: 'MALE' },

--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -65,4 +65,10 @@ export const DATA_OPTIONS: SettingOptionType[] = [
   { title: '전체 데이터 초기화', modalType: 'dataReset' },
 ];
 
-export const INFORMATION_OPTIONS: SettingOptionType[] = [{ title: '의견 보내기', externalUrl: '/' }];
+export const INFORMATION_OPTIONS: SettingOptionType[] = [
+  {
+    title: '의견 보내기',
+    externalUrl:
+      'https://docs.google.com/forms/d/e/1FAIpQLSd-IGtKdkMbo1lLe943G7g7lGlPyIHr6iSZPSm9D0b8y1_4Kw/viewform?usp=sharing&ouid=113670142221324954659',
+  },
+];

--- a/src/hooks/apis/auth/useChangeEmail.ts
+++ b/src/hooks/apis/auth/useChangeEmail.ts
@@ -1,14 +1,16 @@
 import { changeEmail } from '@/api/services/authService';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
 const useChangeEmail = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: changeEmail,
     onSuccess: data => {
+      queryClient.invalidateQueries({ queryKey: ['userEmail'] });
       toast.success(data.message);
       navigate(-1);
     },

--- a/src/hooks/apis/auth/useGetUserDetails.ts
+++ b/src/hooks/apis/auth/useGetUserDetails.ts
@@ -5,6 +5,8 @@ const useGetUserDetails = () => {
   return useQuery({
     queryKey: ['userDetails'],
     queryFn: getUserDetails,
+    staleTime: Infinity,
+    gcTime: Infinity,
   });
 };
 

--- a/src/hooks/apis/auth/useGetUserEmail.ts
+++ b/src/hooks/apis/auth/useGetUserEmail.ts
@@ -5,6 +5,8 @@ const useGetUserEmail = () => {
   return useQuery({
     queryKey: ['userEmail'],
     queryFn: getUserEmail,
+    staleTime: Infinity,
+    gcTime: Infinity,
   });
 };
 

--- a/src/hooks/apis/auth/useUpdateUserDetails.ts
+++ b/src/hooks/apis/auth/useUpdateUserDetails.ts
@@ -1,17 +1,19 @@
 import { updateUserDetails } from '@/api/services/authService';
 import { ProfileFormData } from '@/types/authTypes';
-import { CheckVerifyFieldProps } from '@/types/fieldType';
 import CustomError from '@/utils/CustomError';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UseFormSetError } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
-const useUpdateUserDetails = ({ setError }: Pick<CheckVerifyFieldProps, 'setError'>) => {
+const useUpdateUserDetails = (setError: UseFormSetError<ProfileFormData>) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: updateUserDetails,
     onSuccess: data => {
+      queryClient.invalidateQueries({ queryKey: ['userDetails'] });
       toast.success(data.message);
       navigate(-1);
     },

--- a/src/hooks/apis/category/useAddCategory.ts
+++ b/src/hooks/apis/category/useAddCategory.ts
@@ -24,7 +24,7 @@ const useAddCategory = ({ type, setError }: Props) => {
         queryKey: ['customCategories', type],
       });
       queryClient.invalidateQueries({
-        queryKey: [`activeCategories`, type],
+        queryKey: [`activeCategories`, type === '수입' ? 'income' : 'expense'],
       });
       toast.success(data.message);
       navigate(-1);

--- a/src/hooks/apis/category/useDeleteCategory.ts
+++ b/src/hooks/apis/category/useDeleteCategory.ts
@@ -10,10 +10,10 @@ const useDeleteCategory = (type: IncomeExpenseType) => {
     mutationFn: (id: string) => deleteCategory(id),
     onSuccess: data => {
       queryClient.invalidateQueries({
-        queryKey: ['customCategory', type],
+        queryKey: ['customCategories', type],
       });
       queryClient.invalidateQueries({
-        queryKey: [`activeCategories`, type],
+        queryKey: [`activeCategories`, type === '수입' ? 'income' : 'expense'],
       });
       toast.success(data.message);
     },

--- a/src/hooks/apis/category/useUpdateCategory.ts
+++ b/src/hooks/apis/category/useUpdateCategory.ts
@@ -16,7 +16,7 @@ const useUpdateCategory = (type: IncomeExpenseType) => {
         queryKey: ['customCategories', type],
       });
       queryClient.invalidateQueries({
-        queryKey: [`activeCategories`, type],
+        queryKey: [`activeCategories`, type === '수입' ? 'income' : 'expense'],
       });
       toast.success(data.message);
       navigate(-1);

--- a/src/hooks/apis/category/useUpdateCategoryVisibility.ts
+++ b/src/hooks/apis/category/useUpdateCategoryVisibility.ts
@@ -29,7 +29,7 @@ const useUpdateCategoryVisibility = ({ type }: Props) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [`activeCategories`, type],
+        queryKey: [`activeCategories`, type === '수입' ? 'income' : 'expense'],
       });
     },
     onError: (error, _variables, context) => {

--- a/src/hooks/apis/chart/useGetBarChart.ts
+++ b/src/hooks/apis/chart/useGetBarChart.ts
@@ -1,6 +1,6 @@
 import { getExpenseBarChart, getIncomeBarChart } from '@/api/services/chartService';
 import { IncomeExpenseType } from '@/types/transactionTypes';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 const useGetBarChart = (transactionType: IncomeExpenseType, date: string) => {
   const queryFn = transactionType === '지출' ? getExpenseBarChart : getIncomeBarChart;
@@ -8,6 +8,9 @@ const useGetBarChart = (transactionType: IncomeExpenseType, date: string) => {
   return useQuery({
     queryKey: ['barChart', date, transactionType],
     queryFn: () => queryFn(date),
+    placeholderData: keepPreviousData,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
   });
 };
 

--- a/src/hooks/apis/chart/useGetStackedBarChart.ts
+++ b/src/hooks/apis/chart/useGetStackedBarChart.ts
@@ -1,13 +1,16 @@
 import { getExpenseStackedBarChart, getIncomeStackedBarChart } from '@/api/services/chartService';
 import { IncomeExpenseType } from '@/types/transactionTypes';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 const useGetStackedBarChart = (transactionType: IncomeExpenseType, date: string) => {
   const queryFn = transactionType === '지출' ? getExpenseStackedBarChart : getIncomeStackedBarChart;
 
   return useQuery({
-    queryKey: ['stackedBarChart', transactionType, date],
+    queryKey: ['stackedBarChart', date, transactionType],
     queryFn: () => queryFn(date),
+    placeholderData: keepPreviousData,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
   });
 };
 

--- a/src/hooks/apis/chart/useGetTotalAndSavings.ts
+++ b/src/hooks/apis/chart/useGetTotalAndSavings.ts
@@ -1,13 +1,16 @@
 import { getExpenseTotalAndSavings, getIncomeTotalAndSavings } from '@/api/services/chartService';
 import { IncomeExpenseType } from '@/types/transactionTypes';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 const useGetTotalAndSavings = (transactionType: IncomeExpenseType, date: string) => {
   const queryFn = transactionType === '지출' ? getExpenseTotalAndSavings : getIncomeTotalAndSavings;
 
   return useQuery({
-    queryKey: ['totalAndSavings', transactionType, date],
+    queryKey: ['totalAndSavings', date, transactionType],
     queryFn: () => queryFn(date),
+    placeholderData: keepPreviousData,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
   });
 };
 

--- a/src/hooks/apis/report/useGetWeeklyDetailsInfiniteQuery.ts
+++ b/src/hooks/apis/report/useGetWeeklyDetailsInfiniteQuery.ts
@@ -15,6 +15,8 @@ const useGetWeeklyDetailsInfiniteQuery = (date: string, week: string) => {
     initialPageParam: null,
     getNextPageParam: lastPage => (lastPage.hasNext ? lastPage.nextCursor : undefined),
     enabled: !!week && !!date,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
   });
 };
 

--- a/src/hooks/apis/report/useGetWeeklySummary.ts
+++ b/src/hooks/apis/report/useGetWeeklySummary.ts
@@ -1,10 +1,11 @@
 import { getWeeklySummary } from '@/api/services/reportService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 const useGetWeeklySummary = (date: string) => {
   return useQuery({
     queryKey: ['weeklySummary', date],
     queryFn: () => getWeeklySummary(date),
+    placeholderData: keepPreviousData,
   });
 };
 

--- a/src/hooks/apis/report/useGetWeeklySummary.ts
+++ b/src/hooks/apis/report/useGetWeeklySummary.ts
@@ -6,6 +6,8 @@ const useGetWeeklySummary = (date: string) => {
     queryKey: ['weeklySummary', date],
     queryFn: () => getWeeklySummary(date),
     placeholderData: keepPreviousData,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
   });
 };
 

--- a/src/hooks/apis/report/useGetYearlySummary.ts
+++ b/src/hooks/apis/report/useGetYearlySummary.ts
@@ -1,10 +1,11 @@
 import { getYearlySummary } from '@/api/services/reportService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 const useGetYearlySummary = (date: string) => {
   return useQuery({
     queryKey: ['yearlySummary', date],
     queryFn: () => getYearlySummary(date),
+    placeholderData: keepPreviousData,
   });
 };
 

--- a/src/hooks/apis/report/useGetYearlySummary.ts
+++ b/src/hooks/apis/report/useGetYearlySummary.ts
@@ -6,6 +6,8 @@ const useGetYearlySummary = (date: string) => {
     queryKey: ['yearlySummary', date],
     queryFn: () => getYearlySummary(date),
     placeholderData: keepPreviousData,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
   });
 };
 

--- a/src/hooks/apis/transaction/useAddTransaction.ts
+++ b/src/hooks/apis/transaction/useAddTransaction.ts
@@ -2,8 +2,8 @@ import { addExpenseTransaction, addIncomeTransaction } from '@/api/services/tran
 import { useCalenderDateStore } from '@/stores/useCalenderDateStore';
 import { IncomeExpenseType, TransactionFormDataType } from '@/types/transactionTypes';
 import CustomError from '@/utils/CustomError';
+import invalidateTransactionQueries from '@/utils/invalidateTransactionQueries';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { format } from 'date-fns';
 import { UseFormSetError } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
@@ -14,19 +14,15 @@ interface Props {
 
 const useAddTransaction = ({ type, setError }: Props) => {
   const queryClient = useQueryClient();
-  const date = useCalenderDateStore().calenderDate;
+  const { calenderDate } = useCalenderDateStore();
+
   const mutationFn = type === '지출' ? addExpenseTransaction : addIncomeTransaction;
   const navigate = useNavigate();
 
   return useMutation({
     mutationFn: (body: TransactionFormDataType) => mutationFn(body),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['dailyDetails', format(date, 'yyyy-MM-dd')],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['monthlyTotal', format(date, 'yyyy-MM')],
-      });
+      invalidateTransactionQueries(queryClient, calenderDate);
       navigate('/');
     },
     onError: (error: CustomError<{ field: keyof TransactionFormDataType }>) => {

--- a/src/hooks/apis/transaction/useDeleteTransaction.ts
+++ b/src/hooks/apis/transaction/useDeleteTransaction.ts
@@ -1,26 +1,22 @@
 import { deleteExpenseTransaction, deleteIncomeTransaction } from '@/api/services/transactionService';
 import { useCalenderDateStore } from '@/stores/useCalenderDateStore';
 import { DeleteTransactionReq, IncomeExpenseType } from '@/types/transactionTypes';
+import invalidateTransactionQueries from '@/utils/invalidateTransactionQueries';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { format } from 'date-fns';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
 const useDeleteTransaction = (type: IncomeExpenseType) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const date = useCalenderDateStore().calenderDate;
+  const { calenderDate } = useCalenderDateStore();
+
   const mutationFn = type === '지출' ? deleteExpenseTransaction : deleteIncomeTransaction;
 
   return useMutation({
     mutationFn: ({ id, body }: { id: string; body?: DeleteTransactionReq }) => mutationFn({ id, body }),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['dailyDetails', format(date, 'yyyy-MM-dd')],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['monthlyTotal', format(date, 'yyyy-MM')],
-      });
+      invalidateTransactionQueries(queryClient, calenderDate);
       navigate('/');
     },
     onError: error => {

--- a/src/hooks/apis/transaction/useUpdateTransaction.ts
+++ b/src/hooks/apis/transaction/useUpdateTransaction.ts
@@ -2,8 +2,8 @@ import { updateIncomeTransaction, updateExpenseTransaction } from '@/api/service
 import { useCalenderDateStore } from '@/stores/useCalenderDateStore';
 import { IncomeExpenseType, TransactionFormDataType } from '@/types/transactionTypes';
 import CustomError from '@/utils/CustomError';
+import invalidateTransactionQueries from '@/utils/invalidateTransactionQueries';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { format } from 'date-fns';
 import { UseFormSetError } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
@@ -16,18 +16,13 @@ const useUpdateTransaction = ({
 }) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const date = useCalenderDateStore().calenderDate;
+  const { calenderDate } = useCalenderDateStore();
   const mutationFn = type === '지출' ? updateExpenseTransaction : updateIncomeTransaction;
 
   return useMutation({
     mutationFn: ({ id, body }: { id: string; body: TransactionFormDataType }) => mutationFn(id, body),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['dailyDetails', format(date, 'yyyy-MM-dd')],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['monthlyTotal', format(date, 'yyyy-MM')],
-      });
+      invalidateTransactionQueries(queryClient, calenderDate);
       navigate('/');
     },
     onError: (error: CustomError<{ field: keyof TransactionFormDataType }>) => {

--- a/src/hooks/category/useFilteredCategories .ts
+++ b/src/hooks/category/useFilteredCategories .ts
@@ -1,32 +1,37 @@
 import { SelectOptionsType } from '@/types/fieldType';
-import { TransactionFormDataType } from '@/types/transactionTypes';
 import { useEffect, useState } from 'react';
 
-const useFilteredCategories = (
-  allCategories: SelectOptionsType[],
-  transactionFormData: TransactionFormDataType | undefined,
-  activeCategories: string[] | undefined,
-  isEditPage: boolean,
-) => {
+const useFilteredCategories = (activeCategories: string[] | undefined, currentCategoryName?: string) => {
   const [categoryOptions, setCategoryOptions] = useState<SelectOptionsType[]>([]);
 
   useEffect(() => {
-    if (activeCategories) {
-      const filteredCategory = allCategories
-        .filter(category => {
-          if (isEditPage && transactionFormData) {
-            return activeCategories.includes(category.label) || category.label === transactionFormData.categoryName;
-          }
-          return activeCategories.includes(category.label);
-        })
-        .map(category => ({
-          ...category,
-          visibility: isEditPage && transactionFormData ? category.label !== transactionFormData.categoryName : true,
-        }));
+    if (!activeCategories) return;
 
-      setCategoryOptions(filteredCategory);
+    const deduped = new Set<string>();
+    const result: SelectOptionsType[] = [];
+
+    if (currentCategoryName && !activeCategories.includes(currentCategoryName)) {
+      result.push({
+        label: currentCategoryName,
+        value: currentCategoryName,
+        visibility: false,
+      });
+      deduped.add(currentCategoryName);
     }
-  }, [allCategories, transactionFormData, activeCategories, isEditPage]);
+
+    for (const category of activeCategories) {
+      if (!deduped.has(category)) {
+        result.push({
+          label: category,
+          value: category,
+          visibility: true,
+        });
+        deduped.add(category);
+      }
+    }
+
+    setCategoryOptions(result);
+  }, [activeCategories, currentCategoryName]);
 
   return {
     categoryOptions,

--- a/src/hooks/transaction/useTransactionForm.ts
+++ b/src/hooks/transaction/useTransactionForm.ts
@@ -8,7 +8,6 @@ import { useResetCustomIteration } from '@/hooks/useResetCustomIteration';
 import { merge } from 'lodash';
 import useGetActiveCategory from '@/hooks/apis/category/useGetActiveCategory';
 import useFilteredCategories from '@/hooks/category/useFilteredCategories ';
-import { EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/constants/options';
 
 interface Props {
   transactionType?: IncomeExpenseType;
@@ -31,8 +30,8 @@ const useTransactionForm = ({ transactionType, initialIterationTypeRef }: Props)
   const { data: activeCategories, isPending: isCategoryPending } = useGetActiveCategory(
     isExpense ? 'expense' : 'income',
   );
-  const categories = isExpense ? EXPENSE_CATEGORIES : INCOME_CATEGORIES;
-  const { categoryOptions } = useFilteredCategories(categories, transactionFormData, activeCategories, isEditPage);
+
+  const { categoryOptions } = useFilteredCategories(activeCategories, transactionFormData?.categoryName);
 
   useEffect(() => {
     if (transactionDate) setCalenderDate(new Date(transactionDate));
@@ -56,9 +55,13 @@ const useTransactionForm = ({ transactionType, initialIterationTypeRef }: Props)
 
   useEffect(() => {
     if (categoryOptions.length > 0) {
-      setValue('categoryName', categoryOptions[0].value);
+      if (transactionFormData) {
+        setValue('categoryName', transactionFormData.categoryName);
+      } else {
+        setValue('categoryName', categoryOptions[0].value);
+      }
     }
-  }, [categoryOptions, setValue]);
+  }, [transactionFormData, categoryOptions, setValue]);
 
   return {
     categoryOptions,

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -30,7 +30,6 @@ const useInfiniteScroll = ({
     observer.observe(current);
 
     return () => {
-      observer.unobserve(current);
       observer.disconnect();
     };
   }, [observerRef, hasNextPage, fetchNextPage, isFetchingNextPage]);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,12 +7,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-if (typeof window !== 'undefined') {
-  if (import.meta.env.DEV) {
-    const { worker } = await import('@/mocks/browser');
-    await worker.start();
-  }
-}
+// if (typeof window !== 'undefined') {
+//   if (import.meta.env.DEV) {
+//     const { worker } = await import('@/mocks/browser');
+//     await worker.start();
+//   }
+// }
 
 const queryClient = new QueryClient();
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,12 +7,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-// if (typeof window !== 'undefined') {
-//   if (import.meta.env.DEV) {
-//     const { worker } = await import('@/mocks/browser');
-//     await worker.start();
-//   }
-// }
+if (typeof window !== 'undefined') {
+  if (import.meta.env.DEV) {
+    const { worker } = await import('@/mocks/browser');
+    await worker.start();
+  }
+}
 
 const queryClient = new QueryClient();
 

--- a/src/mocks/handler/authHandlers.ts
+++ b/src/mocks/handler/authHandlers.ts
@@ -1,6 +1,6 @@
 import { endpoints } from '@/api/endpoints';
 import { parseRequestBody } from '@/mocks/utils/parseRequestBody';
-import { delay, http, HttpResponse } from 'msw';
+import { http, HttpResponse } from 'msw';
 import {
   USERNAME_ERROR_MSG,
   USERNAME_SUCCESS_MSG,
@@ -31,8 +31,6 @@ export const authHandlers = [
     return HttpResponse.json({ status: 200, message: NICKNAME_SUCCESS_MSG }, { status: 200 });
   }),
   http.post(endpoints.auth.signup, async ({ request }) => {
-    await delay(5000);
-
     const formData = await request.formData();
 
     const email = formData.get('email') as string;

--- a/src/mocks/handler/categoryHandlers.ts
+++ b/src/mocks/handler/categoryHandlers.ts
@@ -18,7 +18,8 @@ const IncomeCategories = INCOME_CATEGORIES.map(({ value, color }, index) => ({
 }));
 
 export const categoryHandlers = [
-  http.get('category/active', ({ request }) => {
+  http.get('category/active', async ({ request }) => {
+    await delay(5000);
     const url = new URL(request.url);
     const type = url.searchParams.get('type');
 

--- a/src/mocks/handler/categoryHandlers.ts
+++ b/src/mocks/handler/categoryHandlers.ts
@@ -1,5 +1,5 @@
 import { endpoints } from '@/api/endpoints';
-import { http, HttpResponse, delay } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/constants/options';
 import { parseRequestBody } from '../utils/parseRequestBody';
 
@@ -19,7 +19,6 @@ const IncomeCategories = INCOME_CATEGORIES.map(({ value, color }, index) => ({
 
 export const categoryHandlers = [
   http.get('category/active', async ({ request }) => {
-    await delay(5000);
     const url = new URL(request.url);
     const type = url.searchParams.get('type');
 
@@ -122,7 +121,6 @@ export const categoryHandlers = [
 
   http.post(endpoints.category.addExpense, async ({ request }) => {
     const { name } = await parseRequestBody<{ name: string }>(request);
-    await delay(2000);
 
     if (name === '냠냠' || name === '쩝쩝') {
       return HttpResponse.json(
@@ -145,7 +143,6 @@ export const categoryHandlers = [
 
   http.post(endpoints.category.addIncome, async ({ request }) => {
     const { name } = await parseRequestBody<{ name: string }>(request);
-    await delay(2000);
 
     if (name === '주식 배당금') {
       return HttpResponse.json(

--- a/src/mocks/handler/categoryLogsHandler.ts
+++ b/src/mocks/handler/categoryLogsHandler.ts
@@ -1,5 +1,5 @@
 import { CategoryDetailsRes, CategoryLogsType } from '@/types/chartTypes';
-import { delay, http, HttpResponse } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { generateDate } from '@/mocks/utils/createMockTransaction';
 
 const TOTAL_LOGS = 50;
@@ -15,8 +15,6 @@ const generateLog = (index: number): CategoryLogsType => ({
 });
 
 export const categoryLogsHandler = http.get('/chart/:categoryId/section', async ({ request }) => {
-  await delay(3000);
-
   const url = new URL(request.url);
   const cursor = url.searchParams.get('cursor');
   const startIndex = cursor ? parseInt(cursor, 10) : 0;

--- a/src/mocks/handler/chartHandlers.ts
+++ b/src/mocks/handler/chartHandlers.ts
@@ -13,7 +13,7 @@ export const chartHandlers = [
         data: {
           savingCategoryId: 1,
           totalAmount: 546546546,
-          totalSavingsAmount: 4536456,
+          totalSaving: 4536456,
         },
       },
       { status: 200 },
@@ -31,7 +31,7 @@ export const chartHandlers = [
         data: {
           savingCategoryId: 2,
           totalAmount: 2132447,
-          totalSavingsAmount: 2313225,
+          totalSaving: 2313225,
         },
       },
       { status: 200 },

--- a/src/mocks/handler/chartHandlers.ts
+++ b/src/mocks/handler/chartHandlers.ts
@@ -1,9 +1,8 @@
-import { delay, http, HttpResponse } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { createMockChart } from '@/mocks/utils/createMockChart';
 
 export const chartHandlers = [
   http.get('/chart/expense/total', async ({ request }) => {
-    await delay(5000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date');
 
@@ -40,7 +39,6 @@ export const chartHandlers = [
   }),
 
   http.get('/chart/category/expense', async ({ request }) => {
-    await delay(5000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date');
 
@@ -156,7 +154,6 @@ export const chartHandlers = [
   }),
 
   http.get('/chart/expense/bar', async ({ request }) => {
-    await delay(5000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date') ?? '';
     const isYearMonthlyFormat = /^\d{4}-\d{2}$/.test(date);

--- a/src/mocks/handler/chartHandlers.ts
+++ b/src/mocks/handler/chartHandlers.ts
@@ -1,8 +1,9 @@
-import { http, HttpResponse } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 import { createMockChart } from '@/mocks/utils/createMockChart';
 
 export const chartHandlers = [
-  http.get('/chart/expense/total', ({ request }) => {
+  http.get('/chart/expense/total', async ({ request }) => {
+    await delay(5000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date');
 
@@ -13,7 +14,7 @@ export const chartHandlers = [
         data: {
           savingCategoryId: 1,
           totalAmount: 546546546,
-          totalSaving: 4536456,
+          totalSaving: 0,
         },
       },
       { status: 200 },
@@ -38,22 +39,22 @@ export const chartHandlers = [
     );
   }),
 
-  http.get('/chart/category/expense', ({ request }) => {
+  http.get('/chart/category/expense', async ({ request }) => {
+    await delay(5000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date');
 
     const response = {
-      aggregatedData: [
-        {
-          주거비: 35.0,
-          식비: 25.0,
-          쇼핑: 15.0,
-          '건강/의료': 8.0,
-          '문화/취미': 7.0,
-          커피: 6.0,
-          기타: 4.0,
-        },
-      ],
+      aggregatedData: {
+        주거비: 35.0,
+        식비: 25.0,
+        쇼핑: 15.0,
+        '건강/의료': 8.0,
+        '문화/취미': 7.0,
+        커피: 6.0,
+        기타: 4.0,
+      },
+
       categoryColors: {
         주거비: '#4A90E2',
         식비: '#7ED321',
@@ -154,7 +155,8 @@ export const chartHandlers = [
     );
   }),
 
-  http.get('/chart/expense/bar', ({ request }) => {
+  http.get('/chart/expense/bar', async ({ request }) => {
+    await delay(5000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date') ?? '';
     const isYearMonthlyFormat = /^\d{4}-\d{2}$/.test(date);

--- a/src/mocks/handler/loginHandlers.ts
+++ b/src/mocks/handler/loginHandlers.ts
@@ -1,4 +1,4 @@
-import { delay, http, HttpResponse } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { parseRequestBody } from '@/mocks/utils/parseRequestBody';
 import { endpoints } from '@/api/endpoints';
 import { LOGIN_FAIL_MSG, LOGIN_SUCCESS_MSG } from '@/mocks/constants/login';
@@ -7,8 +7,6 @@ import { createMockAccessToken, createMockRefreshToken } from '@/mocks/utils/cre
 
 export const loginHandlers = [
   http.post(endpoints.auth.login, async ({ request }) => {
-    await delay(3000);
-
     const { username, password } = await parseRequestBody<{ username: string; password: string }>(request);
 
     if (username === 'woic' && password === 'abcd1234') {

--- a/src/mocks/handler/totalHandlers.ts
+++ b/src/mocks/handler/totalHandlers.ts
@@ -1,4 +1,4 @@
-import { delay, http, HttpResponse } from 'msw';
+import { http, HttpResponse } from 'msw';
 import {
   createMockMonthlyTransactions,
   createMockWeeklySummary,
@@ -10,7 +10,6 @@ import { generateDate } from '@/mocks/utils/createMockTransaction';
 
 export const totalHandlers = [
   http.get('/report/monthly/total', async ({ request }) => {
-    await delay(5000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date');
 
@@ -36,7 +35,6 @@ export const totalHandlers = [
   }),
 
   http.get('/report/yearly/total', async ({ request }) => {
-    await delay(3000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date');
 
@@ -62,7 +60,6 @@ export const totalHandlers = [
   }),
 
   http.get('/report/weekly/total', async ({ request }) => {
-    await delay(3000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date');
     const targetDate = new Date(date || '');

--- a/src/mocks/handler/totalHandlers.ts
+++ b/src/mocks/handler/totalHandlers.ts
@@ -36,6 +36,7 @@ export const totalHandlers = [
   }),
 
   http.get('/report/yearly/total', async ({ request }) => {
+    await delay(3000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date');
 
@@ -46,7 +47,7 @@ export const totalHandlers = [
     response = {
       yearTotalIncome: income,
       yearTotalExpense: expense,
-      yearTotalBalance: income - expense,
+      yearTotalAmount: income - expense,
       monthlyLogs: createMockYearlySummary(date || format(new Date(), 'yyyy')),
     };
 
@@ -61,6 +62,7 @@ export const totalHandlers = [
   }),
 
   http.get('/report/weekly/total', async ({ request }) => {
+    await delay(3000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date');
     const targetDate = new Date(date || '');

--- a/src/mocks/handler/transactionHandlers.ts
+++ b/src/mocks/handler/transactionHandlers.ts
@@ -1,10 +1,9 @@
-import { delay, http, HttpResponse } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { createRandomAmount } from '../utils/createMockTransaction';
 import { endpoints } from '@/api/endpoints';
 
 export const transactionHandlers = [
   http.get('/report/daily/details', async ({ request }) => {
-    await delay(3000);
     const url = new URL(request.url);
     const date = url.searchParams.get('date');
 
@@ -53,8 +52,6 @@ export const transactionHandlers = [
     );
   }),
   http.post(endpoints.transaction.addExpense, async () => {
-    await delay(3000);
-
     return HttpResponse.json(
       {
         status: 201,
@@ -64,8 +61,6 @@ export const transactionHandlers = [
     );
   }),
   http.post(endpoints.transaction.addIncome, async () => {
-    await delay(3000);
-
     return HttpResponse.json(
       {
         status: 201,
@@ -127,7 +122,6 @@ export const transactionHandlers = [
     );
   }),
   http.put('/expense/:id', async ({ params }) => {
-    await delay(3000);
     const { id } = params;
 
     if (id === '3') {
@@ -149,7 +143,6 @@ export const transactionHandlers = [
     );
   }),
   http.put('/income/:id', async ({ params }) => {
-    await delay(3000);
     const { id } = params;
 
     if (id === '3') {
@@ -174,7 +167,6 @@ export const transactionHandlers = [
     );
   }),
   http.delete('/expense/:id', async ({ params }) => {
-    await delay(3000);
     const { id } = params;
 
     if (id === '3') {
@@ -196,7 +188,6 @@ export const transactionHandlers = [
     );
   }),
   http.delete('/income/:id', async ({ params }) => {
-    await delay(3000);
     const { id } = params;
 
     if (id === '3') {

--- a/src/mocks/utils/createMockChart.ts
+++ b/src/mocks/utils/createMockChart.ts
@@ -7,10 +7,11 @@ export const createMockChart = (date: string, isYearMonthlyFormat: boolean) => {
 
   const result = [];
 
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 6; i++) {
     result.push({
       period: targetDate,
       totalAmount: Math.floor(Math.random() * boundary + 1),
+      label: `${Math.floor(Math.random() * boundary + 1)}만원`,
     });
 
     const formattedDate = isYearMonthlyFormat

--- a/src/pages/AddEditTransactionPage/AddEditTransactionPage.tsx
+++ b/src/pages/AddEditTransactionPage/AddEditTransactionPage.tsx
@@ -35,7 +35,7 @@ const AddEditTransactionPage = () => {
   };
 
   return (
-    <div className="flex flex-col w-full h-screen max-h-fit relative">
+    <div className="flex flex-col w-full min-h-screen max-h-fit relative">
       <DefaultHeader
         label={isEditPage ? '가계부 편집' : '가계부 추가'}
         hasBackButton

--- a/src/pages/AddEditTransactionPage/components/TransactionFields.tsx
+++ b/src/pages/AddEditTransactionPage/components/TransactionFields.tsx
@@ -32,10 +32,6 @@ const TransactionFields = ({ type, options }: Props) => {
     onChange(Number(formattedValue));
   };
 
-  if (!options) {
-    return;
-  }
-
   return (
     <div className="flex flex-col flex-grow min-h-0 mt-7 gap-3.5">
       <PrimaryInput

--- a/src/pages/AddEditTransactionPage/components/TransactionFields.tsx
+++ b/src/pages/AddEditTransactionPage/components/TransactionFields.tsx
@@ -63,6 +63,7 @@ const TransactionFields = ({ type, options }: Props) => {
         options={options}
         type={type}
         hasEditButton
+        errorMessage={errors.categoryName?.message}
         {...register('categoryName')}
       />
       <PrimaryInput

--- a/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
+++ b/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
@@ -15,6 +15,7 @@ import useModal from '@/hooks/useModal';
 import useUpdateTransaction from '@/hooks/apis/transaction/useUpdateTransaction';
 import { getFinalData } from '@/pages/AddEditTransactionPage/utils/filterTransactionForm';
 import LoadingSpinner from '@/components/loading/LoadingSpinner';
+import { LOADING_OPTIONS } from '@/constants/options';
 
 interface Props {
   openEdit: () => void;
@@ -80,7 +81,7 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
     }
   };
 
-  if (isGetTransactionFetching || isCategoryPending) {
+  if (isGetTransactionFetching) {
     return (
       <div className="w-full flex grow items-center justify-center">
         <LoadingSpinner size={30} />
@@ -89,9 +90,9 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
   }
 
   return (
-    <form className="flex flex-col w-full h-full justify-between py-8 px-5" onSubmit={handleSubmit(onSubmit)}>
+    <form className="flex flex-col w-full grow justify-between py-8 px-5" onSubmit={handleSubmit(onSubmit)}>
       <IncomeExpenseButton type={transactionType} onClick={(value: IncomeExpenseType) => setTransactionType(value)} />
-      <TransactionFields type={transactionType} options={options} />
+      <TransactionFields type={transactionType} options={isCategoryPending ? LOADING_OPTIONS : options} />
       <div className="w-full flex justify-between items-center">
         <RepeatCircleButton openModal={openModal} />
         <PrimaryButton

--- a/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
+++ b/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
@@ -14,6 +14,7 @@ import CustomIterationModal from '@/pages/AddEditTransactionPage/components/moda
 import useModal from '@/hooks/useModal';
 import useUpdateTransaction from '@/hooks/apis/transaction/useUpdateTransaction';
 import { getFinalData } from '@/pages/AddEditTransactionPage/utils/filterTransactionForm';
+import LoadingSpinner from '@/components/loading/LoadingSpinner';
 
 interface Props {
   openEdit: () => void;
@@ -42,7 +43,11 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
     type: transactionType,
     setError,
   });
-  const { categoryOptions: options, isGetTransactionFetching } = useTransactionForm({
+  const {
+    categoryOptions: options,
+    isGetTransactionFetching,
+    isCategoryPending,
+  } = useTransactionForm({
     transactionType,
     initialIterationTypeRef,
   });
@@ -75,8 +80,12 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
     }
   };
 
-  if (isGetTransactionFetching) {
-    return <div>로딩중</div>;
+  if (isGetTransactionFetching || isCategoryPending) {
+    return (
+      <div className="w-full flex grow items-center justify-center">
+        <LoadingSpinner size={30} />
+      </div>
+    );
   }
 
   return (

--- a/src/pages/CategoryDetailsPage/CategoryDetailsPage.tsx
+++ b/src/pages/CategoryDetailsPage/CategoryDetailsPage.tsx
@@ -4,7 +4,7 @@ import CategoryOverviewChart from '@/pages/CategoryDetailsPage/components/Catego
 import { useEffect } from 'react';
 import { useTransactionReportTypeStore } from '@/stores/chart/useTransactionReportTypeStore';
 import { useReportTypeStore } from '@/stores/chart/useReportTypeStore';
-import CategoryLogList from '@/pages/CategoryDetailsPage/components/CategoryLogList ';
+import CategoryLogListSection from '@/pages/CategoryDetailsPage/components/CategoryLogListSection';
 
 const CategoryDetailsPage = () => {
   const location = useLocation();
@@ -27,7 +27,12 @@ const CategoryDetailsPage = () => {
         date={date}
         isSavings={isSavings}
       />
-      <CategoryLogList transactionType={transactionType} categoryId={categoryId} date={date} isSavings={isSavings} />
+      <CategoryLogListSection
+        transactionType={transactionType}
+        categoryId={categoryId}
+        date={date}
+        isSavings={isSavings}
+      />
     </div>
   );
 };

--- a/src/pages/CategoryDetailsPage/components/CategoryLogList .tsx
+++ b/src/pages/CategoryDetailsPage/components/CategoryLogList .tsx
@@ -1,72 +1,72 @@
-import SortingButton from '@/components/button/icon/SortingButton';
-import { useRef, useState } from 'react';
 import { formatNumber } from '@/utils/number';
 import { clsx } from 'clsx';
-import { useNavigate } from 'react-router-dom';
-import useCategoryLogsInfiniteQuery from '@/hooks/apis/chart/useCategoryLogsInfiniteQuery';
 import FetchingMessage from '@/components/loading/FetchingMessage';
-import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import { CategoryLogsType } from '@/types/chartTypes';
+import { IncomeExpenseType } from '@/types/transactionTypes';
+import { useNavigate } from 'react-router-dom';
+import Skeleton from '@/components/loading/Skeleton';
 
 interface Props {
-  transactionType: string;
-  categoryId: string;
-  date: string;
+  isEmpty: boolean;
+  isPending: boolean;
   isSavings: boolean;
+  isFetchingNextPage: boolean;
+  allCategoryLogs: CategoryLogsType[];
+  transactionType: IncomeExpenseType;
 }
 
-const CategoryLogList = ({ transactionType, categoryId, date, isSavings }: Props) => {
+const CategoryLogList = ({
+  isEmpty,
+  isPending,
+  isFetchingNextPage,
+  allCategoryLogs,
+  isSavings,
+  transactionType,
+}: Props) => {
   const navigate = useNavigate();
-  const [isDescending, setIsDescending] = useState<boolean>(true);
-  const observerRef = useRef<HTMLDivElement | null>(null);
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useCategoryLogsInfiniteQuery(categoryId, date);
-  useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
-  const allCategoryLogs = data?.pages?.flatMap(page => page.categoryLogs) || [];
-  const totalCount = data?.pages[0]?.countOfLogs ?? 0;
-  const isEmpty = allCategoryLogs?.length === 0;
 
-  const handleClick = () => {
-    setIsDescending(prev => !prev);
-  };
-
-  if (!data) {
-    return <div>로딩중...</div>;
+  if (isPending) {
+    return (
+      <div className="flex flex-col">
+        <div className="px-5 py-3">
+          <Skeleton width="w-[8rem]" height="h-[3rem]" />
+        </div>
+        <div className="flex flex-col gap-2.5 px-8">
+          <Skeleton height="h-[3.5rem]" />
+          <Skeleton height="h-[3.5rem]" />
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div className="w-full flex flex-col flex-grow mt-5">
-      <div className="flex justify-between px-6 py-1.5 items-center w-full h-[3.5rem] border-b border-strokeGray">
-        <span>총 {totalCount}건</span>
-        <SortingButton isDescending={isDescending} onClick={handleClick} />
-      </div>
-      <div className={`w-full ${isEmpty && 'flex grow items-center justify-center'}`}>
-        {isEmpty ? (
-          <span className="text-defaultGrey">내역이 없습니다</span>
-        ) : (
-          allCategoryLogs.map(({ date, transactions }, idx) => (
-            <div key={`${date}-${idx}`} className="w-full flex justify-between">
-              <div className=" w-full flex flex-col flex-grow">
-                <span className="px-5 py-3">{date}</span>
-                {transactions.map(({ id, title, amount }) => (
-                  <div
-                    key={id}
-                    className={clsx(
-                      title ? 'justify-between' : 'justify-end',
-                      (transactionType === '지출' || isSavings) && 'text-sunsetRose',
-                      transactionType === '수입' && !isSavings && 'text-oceanBlue',
-                      `flex items-center px-8 gap-8  h-[4.8rem] cursor-pointer hover:bg-strokeGray active:bg-strokeGray`,
-                    )}
-                    onClick={() => navigate(`/transaction?type=edit&id=${id}`)}>
-                    <span className="text-[#555555]">{title}</span>
-                    <span className="text-lg truncate">{formatNumber(amount)}원</span>
-                  </div>
-                ))}
-              </div>
+    <div className={`w-full ${isEmpty && 'flex grow items-center justify-center'}`}>
+      {isEmpty ? (
+        <span className="text-defaultGrey">내역이 없습니다</span>
+      ) : (
+        allCategoryLogs.map(({ date, transactions }, idx) => (
+          <div key={`${date}-${idx}`} className="w-full flex justify-between">
+            <div className=" w-full flex flex-col flex-grow">
+              <span className="px-5 py-3">{date}</span>
+              {transactions.map(({ id, title, amount }) => (
+                <div
+                  key={id}
+                  className={clsx(
+                    title ? 'justify-between' : 'justify-end',
+                    (transactionType === '지출' || isSavings) && 'text-sunsetRose',
+                    transactionType === '수입' && !isSavings && 'text-oceanBlue',
+                    `flex items-center px-8 gap-8  h-[4.8rem] cursor-pointer hover:bg-strokeGray active:bg-strokeGray`,
+                  )}
+                  onClick={() => navigate(`/transaction?type=edit&id=${id}`)}>
+                  <span className="text-[#555555]">{title}</span>
+                  <span className="text-lg truncate">{formatNumber(amount)}원</span>
+                </div>
+              ))}
             </div>
-          ))
-        )}
-        <FetchingMessage isFetchingNextPage={isFetchingNextPage} />
-      </div>
-      {!isEmpty && <div ref={observerRef} className="h-4" />}
+          </div>
+        ))
+      )}
+      <FetchingMessage isFetchingNextPage={isFetchingNextPage} />
     </div>
   );
 };

--- a/src/pages/CategoryDetailsPage/components/CategoryLogListSection.tsx
+++ b/src/pages/CategoryDetailsPage/components/CategoryLogListSection.tsx
@@ -1,0 +1,52 @@
+import SortingButton from '@/components/button/icon/SortingButton';
+import { useRef, useState } from 'react';
+import useCategoryLogsInfiniteQuery from '@/hooks/apis/chart/useCategoryLogsInfiniteQuery';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import CategoryLogList from '@/pages/CategoryDetailsPage/components/CategoryLogList ';
+import { IncomeExpenseType } from '@/types/transactionTypes';
+
+interface Props {
+  transactionType: IncomeExpenseType;
+  categoryId: string;
+  date: string;
+  isSavings: boolean;
+}
+
+const CategoryLogListSection = ({ transactionType, categoryId, date, isSavings }: Props) => {
+  const [isDescending, setIsDescending] = useState<boolean>(true);
+  const observerRef = useRef<HTMLDivElement | null>(null);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } = useCategoryLogsInfiniteQuery(
+    categoryId,
+    date,
+  );
+  useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
+  const allCategoryLogs = data?.pages?.flatMap(page => page.categoryLogs) || [];
+  const totalCount = data?.pages[0]?.countOfLogs ?? 0;
+  const isEmpty = allCategoryLogs?.length === 0;
+
+  const handleClick = () => {
+    if (!isPending) {
+      setIsDescending(prev => !prev);
+    }
+  };
+
+  return (
+    <div className="w-full flex flex-col flex-grow mt-5">
+      <div className="flex justify-between px-6 py-1.5 items-center w-full h-[3.5rem] border-b border-strokeGray">
+        <span>총 {totalCount}건</span>
+        <SortingButton isDescending={isDescending} onClick={handleClick} />
+      </div>
+      <CategoryLogList
+        transactionType={transactionType}
+        isEmpty={isEmpty}
+        isPending={isPending}
+        isSavings={isSavings}
+        isFetchingNextPage={isFetchingNextPage}
+        allCategoryLogs={allCategoryLogs}
+      />
+      {!isEmpty && <div ref={observerRef} className="h-4" />}
+    </div>
+  );
+};
+
+export default CategoryLogListSection;

--- a/src/pages/CategoryDetailsPage/components/CategoryOverviewChart.tsx
+++ b/src/pages/CategoryDetailsPage/components/CategoryOverviewChart.tsx
@@ -5,6 +5,7 @@ import useGetCategoryDetailsBarChart from '@/hooks/apis/chart/useGetCategoryDeta
 import useGetCategoryDetailsLineChart from '@/hooks/apis/chart/useGetCategoryDetailsLineChart';
 import { ReportType } from '@/types/reportTypes';
 import { IncomeExpenseType } from '@/types/transactionTypes';
+import LoadingSpinner from '@/components/loading/LoadingSpinner';
 
 interface Props {
   reportType: ReportType;
@@ -28,7 +29,11 @@ const CategoryOverviewChart = ({ reportType, transactionType, categoryId, date, 
   );
 
   if ((!monthlyChartData && !isWeekly) || (!weeklyChartData && isWeekly) || isBarChartFetching || isLineChartFetching) {
-    return <div>로딩중..</div>;
+    return (
+      <div className="flex justify-center items-center w-full h-[39rem]">
+        <LoadingSpinner size={30} />
+      </div>
+    );
   }
 
   const period = isWeekly ? weeklyChartData?.period : monthlyChartData?.period;

--- a/src/pages/CategoryDetailsPage/components/barChart/CategoryBarChart.tsx
+++ b/src/pages/CategoryDetailsPage/components/barChart/CategoryBarChart.tsx
@@ -32,7 +32,7 @@ const CategoryBarChart = ({ transactionType, monthlyAmounts }: Props) => {
       <div className="min-w-[700px]">
         <ResponsiveContainer width="100%" height={300}>
           <BarChart data={monthlyAmounts} margin={{ top: 30, right: 10, bottom: 0, left: 10 }} barSize={25}>
-            <XAxis type="category" dataKey="month" axisLine={false} tickLine={false} interval={0} />
+            <XAxis type="category" dataKey="period" axisLine={false} tickLine={false} interval={0} />
             <YAxis type="number" dataKey="totalAmount" hide domain={[1, maxAmount]} />
             <Tooltip content={<CustomizedTooltip />} />
             <Bar

--- a/src/pages/CategoryDetailsPage/components/barChart/CustomizedLabel.tsx
+++ b/src/pages/CategoryDetailsPage/components/barChart/CustomizedLabel.tsx
@@ -17,11 +17,13 @@ const CustomizedLabel = (props: Props) => {
   const maxLength = 8;
   const truncatedValue = String(value).length > maxLength ? String(value).substring(0, maxLength) + '...' : value;
 
+  const adjustedY = Number(value) === 0 ? 255 : numericY - radius;
+
   return (
     <g>
       <text
         x={numericX + numericWidth / 2}
-        y={numericY - radius}
+        y={adjustedY}
         fill="#00000"
         textAnchor="middle"
         dominantBaseline="middle"

--- a/src/pages/ChartPage/ChartPage.tsx
+++ b/src/pages/ChartPage/ChartPage.tsx
@@ -14,7 +14,7 @@ const ChartPage = () => {
   return (
     <div className="flex flex-col w-full min-h-screen">
       <DateControlHeader headerDate={chartHeaderDate} setHeaderDate={setChartHeaderDate} />
-      <div className="grow">
+      <div className="flex flex-col grow">
         <div className="w-full flex justify-between items-center p-5">
           <ReportTypeSelection />
           <TransactionTypeButton />

--- a/src/pages/ChartPage/components/categories/CategoryChartBoard.tsx
+++ b/src/pages/ChartPage/components/categories/CategoryChartBoard.tsx
@@ -3,15 +3,26 @@ import useFormattedReportDate from '@/hooks/chart/useFormattedReportDate';
 import { useTransactionReportTypeStore } from '@/stores/chart/useTransactionReportTypeStore';
 import StackedBarChart from '@/pages/ChartPage/components/categories/StackedBarChart';
 import CategoryDashBoard from '@/pages/ChartPage/components/categories/CategoryDashBoard';
+import Skeleton from '@/components/loading/Skeleton';
 
 const CategoryChartBoard = () => {
   const { currentTransactionType } = useTransactionReportTypeStore();
   const formattedDate = useFormattedReportDate();
 
-  const { data: stackedBarChartData, isFetching } = useGetStackedBarChart(currentTransactionType, formattedDate);
+  const { data: stackedBarChartData, isPending } = useGetStackedBarChart(currentTransactionType, formattedDate);
 
-  if (!stackedBarChartData || isFetching) {
-    return <div>로딩중..</div>;
+  if (!stackedBarChartData || isPending) {
+    return (
+      <>
+        <div className="p-5">
+          <Skeleton height="h-[5rem]" />
+        </div>
+        <div className="flex flex-col gap-2 px-8 pb-4">
+          <Skeleton height="h-[3.5rem]" />
+          <Skeleton height="h-[3.5rem]" />
+        </div>
+      </>
+    );
   }
 
   return (

--- a/src/pages/ChartPage/components/categories/CategoryDashBoard.tsx
+++ b/src/pages/ChartPage/components/categories/CategoryDashBoard.tsx
@@ -19,32 +19,36 @@ const CategoryDashBoard = ({ categoryCharts }: Props) => {
 
   return (
     <div className="flex flex-col pl-8 pr-5 pb-4">
-      {categoryCharts.map(categoryItem => (
-        <div
-          className="flex justify-between gap-3.5 cursor-pointer py-3"
-          key={categoryItem.id}
-          onClick={() =>
-            handleClickCategoryChart(
-              navigate,
-              categoryItem.id,
-              categoryItem.name,
-              currentTransactionType,
-              currentReportType,
-              date,
-            )
-          }>
-          <div className="flex w-fit gap-4.5">
-            <span style={{ color: categoryItem.color }}>{categoryItem.name}</span>
-            <span>{categoryItem.rate}%</span>
-          </div>
-          <div className="flex max-w-2/5 w-fit gap-2.5">
-            <span className="whitespace-nowrap truncate">{formatNumber(categoryItem.amount)}원</span>
-            <div className="w-[2.4rem]">
-              <RightArrowButton />
+      {categoryCharts.length === 0 ? (
+        <div className="text-center text-defaultGrey">내역이 없습니다.</div>
+      ) : (
+        categoryCharts.map(categoryItem => (
+          <div
+            className="flex justify-between gap-3.5 cursor-pointer py-3"
+            key={categoryItem.id}
+            onClick={() =>
+              handleClickCategoryChart(
+                navigate,
+                categoryItem.id,
+                categoryItem.name,
+                currentTransactionType,
+                currentReportType,
+                date,
+              )
+            }>
+            <div className="flex w-fit gap-4.5">
+              <span style={{ color: categoryItem.color }}>{categoryItem.name}</span>
+              <span>{categoryItem.rate}%</span>
+            </div>
+            <div className="flex max-w-2/5 w-fit gap-2.5">
+              <span className="whitespace-nowrap truncate">{formatNumber(categoryItem.amount)}원</span>
+              <div className="w-[2.4rem]">
+                <RightArrowButton />
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        ))
+      )}
     </div>
   );
 };

--- a/src/pages/ChartPage/components/categories/StackedBarChart.tsx
+++ b/src/pages/ChartPage/components/categories/StackedBarChart.tsx
@@ -27,7 +27,15 @@ const StackedBarChart = ({ categoryColors, aggregatedData }: Props) => {
               stackId="a"
               fill={categoryColors[key]}
               barSize={500}
-              radius={index === 0 ? [10, 0, 0, 10] : index === lastIndex ? [0, 10, 10, 0] : [0, 0, 0, 0]}
+              radius={
+                colorKeys.length === 1
+                  ? [10, 10, 10, 10]
+                  : index === 0
+                    ? [10, 0, 0, 10]
+                    : index === lastIndex
+                      ? [0, 10, 10, 0]
+                      : [0, 0, 0, 0]
+              }
             />
           ))}
         </BarChart>

--- a/src/pages/ChartPage/components/categories/StackedBarChart.tsx
+++ b/src/pages/ChartPage/components/categories/StackedBarChart.tsx
@@ -14,7 +14,7 @@ const StackedBarChart = ({ categoryColors, aggregatedData }: Props) => {
     <div className="w-full h-[75px] flex justify-center items-center">
       <ResponsiveContainer width="100%" height="100%">
         <BarChart
-          data={aggregatedData}
+          data={[aggregatedData]}
           layout="vertical"
           margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
           barCategoryGap={0}>

--- a/src/pages/ChartPage/components/period/CustomXAxisTick.tsx
+++ b/src/pages/ChartPage/components/period/CustomXAxisTick.tsx
@@ -1,0 +1,31 @@
+interface CustomXAxisTickProps {
+  x: number;
+  y: number;
+  payload: {
+    value: string;
+    [key: string]: any;
+  };
+  onClickTick: (period: string) => void;
+  currentReportType: string;
+}
+
+const CustomXAxisTick = ({ x, y, payload, onClickTick, currentReportType }: CustomXAxisTickProps) => {
+  const period = payload.value;
+
+  const formatted = currentReportType === '월별' ? `${period.slice(-2)}월` : `${period.slice(0, 4)}`;
+
+  return (
+    <text
+      x={x}
+      y={y}
+      dy={16}
+      textAnchor="middle"
+      fill="#000"
+      className="cursor-pointer"
+      onClick={() => onClickTick(period)}>
+      {formatted}
+    </text>
+  );
+};
+
+export default CustomXAxisTick;

--- a/src/pages/ChartPage/components/period/PeriodComparisonChart.tsx
+++ b/src/pages/ChartPage/components/period/PeriodComparisonChart.tsx
@@ -1,4 +1,4 @@
-import { Bar, BarChart, Cell, ResponsiveContainer, XAxis, YAxis } from 'recharts';
+import { Bar, BarChart, Cell, LabelList, ResponsiveContainer, XAxis, YAxis } from 'recharts';
 import PeriodSummary from '@/pages/ChartPage/components/period/PeriodSummary';
 import { useTransactionReportTypeStore } from '@/stores/chart/useTransactionReportTypeStore';
 import { useReportTypeStore } from '@/stores/chart/useReportTypeStore';
@@ -46,7 +46,6 @@ const PeriodComparisonChart = () => {
             <YAxis type="number" hide scale="pow" exponent={0.5} domain={[1, 'auto']} />
             <Bar
               dataKey={'totalAmount'}
-              label={{ position: 'top', fill: '#000000', fontSize: 14 }}
               onClick={target => handleBarCharClick(target.period)}
               className="cursor-pointer">
               {barChartData.totalAmounts.map((entry, index) => (
@@ -55,6 +54,7 @@ const PeriodComparisonChart = () => {
                   fill={index === barChartData.totalAmounts.length - 1 ? '#e7f6d1' : '#E6E6E6'}
                 />
               ))}
+              <LabelList dataKey="label" position="top" fill="#000000" fontSize={14} />
             </Bar>
           </BarChart>
         </ResponsiveContainer>

--- a/src/pages/ChartPage/components/period/PeriodComparisonChart.tsx
+++ b/src/pages/ChartPage/components/period/PeriodComparisonChart.tsx
@@ -6,6 +6,7 @@ import { useHeaderDateStore } from '@/stores/useHeaderDateStore';
 import useGetBarChart from '@/hooks/apis/chart/useGetBarChart';
 import useFormattedReportDate from '@/hooks/chart/useFormattedReportDate';
 import Skeleton from '@/components/loading/Skeleton';
+import CustomXAxisTick from './CustomXAxisTick';
 
 const PeriodComparisonChart = () => {
   const formattedDate = useFormattedReportDate();
@@ -43,7 +44,7 @@ const PeriodComparisonChart = () => {
         differenceAmount={barChartData.differenceAmount}
         averageAmount={barChartData.averageAmount}
       />
-      <div className="w-full h-[250px] flex justify-center items-center ">
+      <div className="w-full h-[250px] mb-4 flex justify-center items-center relative">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={barChartData.totalAmounts} margin={{ top: 20, right: 10, bottom: 0, left: 10 }}>
             <XAxis
@@ -52,15 +53,16 @@ const PeriodComparisonChart = () => {
               axisLine={false}
               tickLine={false}
               interval={0}
-              tickFormatter={tickItem =>
-                `${currentReportType === '월별' ? `${tickItem.slice(-2)}월` : `${tickItem.slice(0, 4)}`}`
-              }
+              tick={props => (
+                <CustomXAxisTick {...props} onClickTick={handleBarCharClick} currentReportType={currentReportType} />
+              )}
             />
             <YAxis type="number" hide scale="pow" exponent={0.5} domain={[1, 'auto']} />
             <Bar
               dataKey={'totalAmount'}
               onClick={target => handleBarCharClick(target.period)}
-              className="cursor-pointer">
+              className="cursor-pointer"
+              background={{ fill: '#ffffff' }}>
               {barChartData.totalAmounts.map((entry, index) => (
                 <Cell
                   key={entry.period}

--- a/src/pages/ChartPage/components/period/PeriodComparisonChart.tsx
+++ b/src/pages/ChartPage/components/period/PeriodComparisonChart.tsx
@@ -5,6 +5,7 @@ import { useReportTypeStore } from '@/stores/chart/useReportTypeStore';
 import { useHeaderDateStore } from '@/stores/useHeaderDateStore';
 import useGetBarChart from '@/hooks/apis/chart/useGetBarChart';
 import useFormattedReportDate from '@/hooks/chart/useFormattedReportDate';
+import Skeleton from '@/components/loading/Skeleton';
 
 const PeriodComparisonChart = () => {
   const formattedDate = useFormattedReportDate();
@@ -12,14 +13,26 @@ const PeriodComparisonChart = () => {
   const { currentTransactionType } = useTransactionReportTypeStore();
   const { currentReportType } = useReportTypeStore();
 
-  const { data: barChartData, isFetching } = useGetBarChart(currentTransactionType, formattedDate);
+  const { data: barChartData, isPending } = useGetBarChart(currentTransactionType, formattedDate);
 
   const handleBarCharClick = (date: string) => {
     setChartHeaderDate(new Date(date));
   };
 
-  if (!barChartData || isFetching) {
-    return <div>로딩중..</div>;
+  if (!barChartData || isPending) {
+    return (
+      <div className="flex flex-col grow p-5 gap-30">
+        <div className="flex flex-col gap-3">
+          <Skeleton width="w-[80%]" height="h-[3rem]" />
+          <Skeleton width="w-1/2" height="h-[2.4rem]" />
+        </div>
+        <div className="flex gap-6 grow">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <Skeleton key={index} width="w-1/6" height="h-[20rem]" />
+          ))}
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/pages/ChartPage/components/summary/ReportSummary.tsx
+++ b/src/pages/ChartPage/components/summary/ReportSummary.tsx
@@ -11,20 +11,20 @@ const ReportSummary = () => {
   const { currentReportType } = useReportTypeStore();
   const { currentTransactionType } = useTransactionReportTypeStore();
   const formattedDate = useFormattedReportDate();
-  const { data: totalAndSavings, isFetching } = useGetTotalAndSavings(currentTransactionType, formattedDate);
+  const { data: totalAndSavings, isPending } = useGetTotalAndSavings(currentTransactionType, formattedDate);
 
   const categoryName = '저축/투자';
+
   return (
     <div className="w-full flex justify-between px-8 py-4 gap-3.5">
-      {!totalAndSavings || isFetching ? (
-        <div>로딩중 ..</div>
-      ) : (
-        <>
-          <SummaryItem title="총액" total={totalAndSavings.totalAmount} />
-          <SummaryItem
-            title="저축/투자"
-            total={totalAndSavings.totalSaving}
-            onClick={() =>
+      <>
+        <SummaryItem title="총액" isPending={isPending} total={totalAndSavings?.totalAmount} />
+        <SummaryItem
+          title="저축/투자"
+          isPending={isPending}
+          total={totalAndSavings?.totalSaving}
+          onClick={() => {
+            if (!isPending && totalAndSavings)
               handleClickCategoryChart(
                 navigate,
                 totalAndSavings.savingCategoryId,
@@ -33,11 +33,10 @@ const ReportSummary = () => {
                 currentReportType,
                 formattedDate,
                 true,
-              )
-            }
-          />
-        </>
-      )}
+              );
+          }}
+        />
+      </>
     </div>
   );
 };

--- a/src/pages/ChartPage/components/summary/ReportSummary.tsx
+++ b/src/pages/ChartPage/components/summary/ReportSummary.tsx
@@ -23,7 +23,7 @@ const ReportSummary = () => {
           <SummaryItem title="총액" total={totalAndSavings.totalAmount} />
           <SummaryItem
             title="저축/투자"
-            total={totalAndSavings.totalSavingsAmount}
+            total={totalAndSavings.totalSaving}
             onClick={() =>
               handleClickCategoryChart(
                 navigate,

--- a/src/pages/ChartPage/components/summary/SummaryItem.tsx
+++ b/src/pages/ChartPage/components/summary/SummaryItem.tsx
@@ -1,17 +1,23 @@
+import Skeleton from '@/components/loading/Skeleton';
 import { formatNumber } from '@/utils/number';
 import clsx from 'clsx';
 
 interface Props {
   title: string;
-  total: number;
+  total?: number;
+  isPending: boolean;
   onClick?: () => void;
 }
 
-const SummaryItem = ({ title, total, onClick }: Props) => {
+const SummaryItem = ({ title, total, isPending, onClick }: Props) => {
   return (
     <div className={clsx('flex flex-col w-1/2', onClick && 'cursor-pointer hover:bg-strokeGray')} onClick={onClick}>
       <span>{title}</span>
-      <span className="text-xl truncate">{formatNumber(total)}원</span>
+      {(!total && total !== 0) || isPending ? (
+        <Skeleton width="h-[3rem]" />
+      ) : (
+        <span className="text-xl truncate">{formatNumber(total)}원</span>
+      )}
     </div>
   );
 };

--- a/src/pages/IterationDataPage/IterationDataPage.tsx
+++ b/src/pages/IterationDataPage/IterationDataPage.tsx
@@ -1,48 +1,17 @@
-import TransactionDetailItem from '@/components/detailItem/TransactionDetailItem';
 import DefaultHeader from '@/components/header/DefaultHeader';
-import useGetIterationData from '@/hooks/apis/transaction/useGetIterationData';
-import { IncomeExpenseType } from '@/types/transactionTypes';
-import { clsx } from 'clsx';
 import { useLocation } from 'react-router-dom';
+import IterationDataListSection from '@/pages/IterationDataPage/components/IterationDataListSection';
+import { IncomeExpenseType } from '@/types/transactionTypes';
 
 const IterationDataPage = () => {
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const type = queryParams.get('type') || '지출';
 
-  const { data: iterationData, isPending } = useGetIterationData(type as IncomeExpenseType);
-
-  if (!iterationData || isPending) {
-    return <div>로딩중...</div>;
-  }
-
   return (
-    <div>
+    <div className="w-full min-h-screen flex flex-col">
       <DefaultHeader label={`반복 ${type} 데이터`} hasBackButton />
-      <div className="w-full px-5 py-3">
-        <p
-          className={clsx(
-            type === '지출' && 'text-sunsetRose',
-            type === '수입' && 'text-oceanBlue',
-            'font-semibold text-lg',
-          )}>
-          총액 : {iterationData.totalAmount.toLocaleString()}원
-        </p>
-      </div>
-      <div className="w-full flex flex-col items-center gap-2.5">
-        {iterationData.iterationAccountBooks.map(({ id, color, categoryName, title, isIteration, type, cost }) => (
-          <TransactionDetailItem
-            key={id}
-            id={id}
-            color={color}
-            categoryName={categoryName}
-            title={title}
-            isIteration={isIteration}
-            type={type}
-            cost={cost}
-          />
-        ))}
-      </div>
+      <IterationDataListSection type={type as IncomeExpenseType} />
     </div>
   );
 };

--- a/src/pages/IterationDataPage/components/IterationDataListSection.tsx
+++ b/src/pages/IterationDataPage/components/IterationDataListSection.tsx
@@ -1,0 +1,51 @@
+import { clsx } from 'clsx';
+import TransactionDetailItem from '@/components/detailItem/TransactionDetailItem';
+import { IncomeExpenseType } from '@/types/transactionTypes';
+import LoadingSpinner from '@/components/loading/LoadingSpinner';
+import useGetIterationData from '@/hooks/apis/transaction/useGetIterationData';
+
+interface Props {
+  type: IncomeExpenseType;
+}
+
+const IterationDataListSection = ({ type }: Props) => {
+  const { data: iterationData, isPending: isGetIterationDataPending } = useGetIterationData(type as IncomeExpenseType);
+
+  if (!iterationData || isGetIterationDataPending) {
+    return (
+      <div className="w-full flex grow justify-center items-center">
+        <LoadingSpinner size={30} />
+      </div>
+    );
+  }
+  return (
+    <>
+      <div className="w-full px-5 py-3">
+        <p
+          className={clsx(
+            type === '지출' && 'text-sunsetRose',
+            type === '수입' && 'text-oceanBlue',
+            'font-semibold text-lg',
+          )}>
+          총액 : {iterationData.totalAmount.toLocaleString()}원
+        </p>
+      </div>
+      <div className="w-full flex flex-col items-center gap-2.5">
+        {iterationData.iterationAccountBooks.map(({ id, color, categoryName, title, isIteration, type, cost }) => (
+          <TransactionDetailItem
+            key={id}
+            id={id}
+            color={color}
+            categoryName={categoryName}
+            title={title}
+            isIteration={isIteration}
+            type={type}
+            cost={cost}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default IterationDataListSection;

--- a/src/pages/MonthWeekPage/MonthWeekPage.tsx
+++ b/src/pages/MonthWeekPage/MonthWeekPage.tsx
@@ -1,31 +1,15 @@
 import DateControlHeader from '@/components/header/DateControlHeader';
-import MonthlyOverview from '@/pages/MonthWeekPage/components/MonthlyOverview';
-import TransactionSummary from '@/components/summary/TransactionSummary';
 import TapBar from '@/components/tapbar/TapBar';
-import useGetYearlySummary from '@/hooks/apis/report/useGetYearlySummary';
 import { useHeaderDateStore } from '@/stores/useHeaderDateStore';
-import { format } from 'date-fns';
+import YearlySummarySection from '@/pages/MonthWeekPage/components/YearlySummarySection';
 
 const MonthWeekPage = () => {
   const { monthWeekHeaderDate, setMonthWeekHeaderDate } = useHeaderDateStore();
-  const targetYear = format(monthWeekHeaderDate, 'yyyy');
-  const { data: yearlySummaryData, isFetching } = useGetYearlySummary(targetYear);
 
   return (
     <div className="w-full h-fit min-h-screen max-h-fit flex flex-col relative">
       <DateControlHeader headerDate={monthWeekHeaderDate} setHeaderDate={setMonthWeekHeaderDate} />
-      {isFetching || !yearlySummaryData ? (
-        <div>로딩중</div>
-      ) : (
-        <div className="grow">
-          <TransactionSummary
-            income={yearlySummaryData.yearTotalIncome}
-            expense={yearlySummaryData.yearTotalExpense}
-            total={yearlySummaryData.yearTotalBalance}
-          />
-          <MonthlyOverview targetYear={targetYear} monthlyLogs={yearlySummaryData.monthlyLogs} />
-        </div>
-      )}
+      <YearlySummarySection />
       <TapBar page="month-week" />
     </div>
   );

--- a/src/pages/MonthWeekPage/components/WeeklyOverview.tsx
+++ b/src/pages/MonthWeekPage/components/WeeklyOverview.tsx
@@ -1,6 +1,7 @@
 import LogItem from '@/pages/MonthWeekPage/components/LogItem';
 import { useNavigate } from 'react-router-dom';
 import useGetWeeklySummary from '@/hooks/apis/report/useGetWeeklySummary';
+import Skeleton from '@/components/loading/Skeleton';
 
 interface Props {
   targetDate: string;
@@ -8,7 +9,7 @@ interface Props {
 
 const WeeklyOverview = ({ targetDate }: Props) => {
   const navigate = useNavigate();
-  const { data: weeklyLogs, isFetching } = useGetWeeklySummary(targetDate);
+  const { data: weeklyLogs, isPending } = useGetWeeklySummary(targetDate);
 
   const handleClick = (week: number) => {
     navigate(`/weeklyDetails?date=${targetDate}&week=${week}`);
@@ -16,8 +17,14 @@ const WeeklyOverview = ({ targetDate }: Props) => {
 
   return (
     <div className="w-[90%] mr-[5%] border border-strokeGray mb-2.5">
-      {!weeklyLogs || isFetching ? (
-        <div>로딩중</div>
+      {!weeklyLogs || isPending ? (
+        <div className="flex flex-col grow gap-1.5 p-3">
+          <Skeleton height="h-[4.5rem]" />
+          <Skeleton height="h-[4.5rem]" />
+          <Skeleton height="h-[4.5rem]" />
+          <Skeleton height="h-[4.5rem]" />
+          <Skeleton height="h-[4.5rem]" />
+        </div>
       ) : (
         weeklyLogs.map((log, index) => (
           <LogItem

--- a/src/pages/MonthWeekPage/components/YearlySummarySection.tsx
+++ b/src/pages/MonthWeekPage/components/YearlySummarySection.tsx
@@ -1,0 +1,32 @@
+import MonthlyOverview from '@/pages/MonthWeekPage/components/MonthlyOverview';
+import TransactionSummary from '@/components/summary/TransactionSummary';
+import useGetYearlySummary from '@/hooks/apis/report/useGetYearlySummary';
+import { useHeaderDateStore } from '@/stores/useHeaderDateStore';
+import { format } from 'date-fns';
+import LoadingSpinner from '@/components/loading/LoadingSpinner';
+
+const YearlySummarySection = () => {
+  const { monthWeekHeaderDate } = useHeaderDateStore();
+  const targetYear = format(monthWeekHeaderDate, 'yyyy');
+  const { data: yearlySummaryData, isPending } = useGetYearlySummary(targetYear);
+
+  if (isPending || !yearlySummaryData) {
+    return (
+      <div className="flex flex-col grow justify-center items-center">
+        <LoadingSpinner size={30} />
+      </div>
+    );
+  }
+  return (
+    <div className="grow">
+      <TransactionSummary
+        income={yearlySummaryData.yearTotalIncome}
+        expense={yearlySummaryData.yearTotalExpense}
+        total={yearlySummaryData.yearTotalAmount}
+      />
+      <MonthlyOverview targetYear={targetYear} monthlyLogs={yearlySummaryData.monthlyLogs} />
+    </div>
+  );
+};
+
+export default YearlySummarySection;

--- a/src/pages/SettingPage/SettingPage.tsx
+++ b/src/pages/SettingPage/SettingPage.tsx
@@ -12,8 +12,8 @@ import { useNavigate } from 'react-router-dom';
 const SettingPage = () => {
   const navigate = useNavigate();
   const [selectedModal, setSelectedModal] = useState<ModalType>(null);
-  const { mutate: logout } = useLogout();
-  const { mutate: resetData } = useResetData({ closeModal: () => setSelectedModal(null) });
+  const { mutate: logout, isPending: isLogoutPending } = useLogout();
+  const { mutate: resetData, isPending: isResetPending } = useResetData({ closeModal: () => setSelectedModal(null) });
 
   const handleOptionClick = ({ to, modalType, externalUrl }: Omit<SettingOptionType, 'title'>) => {
     if (to) {
@@ -41,13 +41,19 @@ const SettingPage = () => {
       </div>
       <TapBar page="setting" />
       {selectedModal === 'logout' && (
-        <DefaultModal content="로그아웃 하시겠습니까?" onClick={logout} onClose={handleModalClose} />
+        <DefaultModal
+          content="로그아웃 하시겠습니까?"
+          onClick={logout}
+          onClose={handleModalClose}
+          isPending={isLogoutPending}
+        />
       )}
       {selectedModal === 'dataReset' && (
         <DefaultModal
           content={`초기화하게 되면\n입력된 모든 가계부 데이터가 삭제됩니다.\n전체 데이터를 초기화 하시겠습니까?`}
           onClick={resetData}
           onClose={handleModalClose}
+          isPending={isResetPending}
         />
       )}
     </div>

--- a/src/pages/UpdateEmailPage/components/UpdateEmailForm.tsx
+++ b/src/pages/UpdateEmailPage/components/UpdateEmailForm.tsx
@@ -7,6 +7,7 @@ import EmailField from '@/components/input/auth/EmailField';
 import { useEmailFieldStore } from '@/stores/fields/useEmailFieldStore';
 import useChangeEmail from '@/hooks/apis/auth/useChangeEmail';
 import { omit } from 'lodash';
+import LoadingSpinner from '@/components/loading/LoadingSpinner';
 
 const UpdateEmailForm = () => {
   const {
@@ -14,8 +15,8 @@ const UpdateEmailForm = () => {
     formState: { isValid, errors },
   } = useFormContext<EmailChangeData>();
   const { sendEmailStatus, emailCodeStatus } = useEmailFieldStore();
-  const { data: userEmail, isPending } = useGetUserEmail();
-  const { mutate: changeEmail } = useChangeEmail();
+  const { data: userEmail, isPending: isGetUserEmailPending } = useGetUserEmail();
+  const { mutate: changeEmail, isPending: isUpdateEmailPending } = useChangeEmail();
 
   const buttonDisabled = !isValid || !errors || !sendEmailStatus.isVerify || !emailCodeStatus.isVerify;
 
@@ -24,8 +25,12 @@ const UpdateEmailForm = () => {
     changeEmail(postData);
   };
 
-  if (!userEmail || isPending) {
-    return <div>로딩중..</div>;
+  if (!userEmail || isGetUserEmailPending) {
+    return (
+      <div className="w-full flex grow justify-center items-center">
+        <LoadingSpinner size={30} />
+      </div>
+    );
   }
 
   return (
@@ -35,7 +40,7 @@ const UpdateEmailForm = () => {
         <EmailField emailFieldName="newEmail" purpose="changeEmail" />
       </div>
       <div className="flex justify-end w-full">
-        <PrimaryButton label="이메일 변경" disabled={buttonDisabled} type="submit" />
+        <PrimaryButton label="이메일 변경" disabled={buttonDisabled} type="submit" isPending={isUpdateEmailPending} />
       </div>
     </form>
   );

--- a/src/pages/UpdatePasswordPage/UpdatePasswordPage.tsx
+++ b/src/pages/UpdatePasswordPage/UpdatePasswordPage.tsx
@@ -10,7 +10,7 @@ const UpdatePasswordPage = () => {
     defaultValues: {
       currentPassword: '',
       newPassword: '',
-      passwordConfirm: '',
+      confirmNewPassword: '',
     },
     resolver: zodResolver(changePasswordSchema),
     mode: 'onChange',

--- a/src/pages/UpdatePasswordPage/components/UpdatePasswordForm.tsx
+++ b/src/pages/UpdatePasswordPage/components/UpdatePasswordForm.tsx
@@ -3,19 +3,31 @@ import PrimaryButton from '@/components/button/PrimaryButton';
 import { Controller, useFormContext } from 'react-hook-form';
 import { ChangePasswordData } from '@/types/authTypes';
 import useUpdatePassword from '@/hooks/apis/auth/useUpdatePassword';
+import { useEffect } from 'react';
 
 const UpdatePasswordForm = () => {
   const {
     control,
     handleSubmit,
     setError,
+    watch,
+    trigger,
     formState: { errors, isValid },
   } = useFormContext<ChangePasswordData>();
-  const { mutate: updatePassword } = useUpdatePassword(setError);
+  const { mutate: updatePassword, isPending } = useUpdatePassword(setError);
 
   const onSubmit = (data: ChangePasswordData) => {
     updatePassword(data);
   };
+
+  useEffect(() => {
+    const subscription = watch((_, { name }) => {
+      if (name === 'newPassword') {
+        trigger('confirmNewPassword');
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [watch, trigger]);
 
   return (
     <form className="flex flex-col justify-between grow px-5 py-8" onSubmit={handleSubmit(onSubmit)}>
@@ -40,20 +52,20 @@ const UpdatePasswordForm = () => {
           )}
         />
         <Controller
-          name="passwordConfirm"
+          name="confirmNewPassword"
           control={control}
           render={({ field }) => (
             <PrimaryInput
               {...field}
               label="비밀번호 재입력"
               type="password"
-              errorMessage={errors.passwordConfirm?.message}
+              errorMessage={errors.confirmNewPassword?.message}
             />
           )}
         />
       </div>
       <div className="flex justify-end w-full">
-        <PrimaryButton label="비밀번호 변경" disabled={!isValid} type="submit" />
+        <PrimaryButton label="비밀번호 변경" disabled={!isValid} type="submit" isPending={isPending} />
       </div>
     </form>
   );

--- a/src/pages/WeeklyDetailsPage/WeeklyDetailsPage.tsx
+++ b/src/pages/WeeklyDetailsPage/WeeklyDetailsPage.tsx
@@ -1,61 +1,11 @@
-import TransactionDetailItem from '@/components/detailItem/TransactionDetailItem';
 import DefaultHeader from '@/components/header/DefaultHeader';
-import FetchingMessage from '@/components/loading/FetchingMessage';
-import TransactionSummary from '@/components/summary/TransactionSummary';
-import useGetWeeklyDetailsInfiniteQuery from '@/hooks/apis/report/useGetWeeklyDetailsInfiniteQuery';
-import useInfiniteScroll from '@/hooks/useInfiniteScroll';
-import { format } from 'date-fns';
-import { useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import WeeklyDetailsSection from '@/pages/WeeklyDetailsPage/components/WeeklyDetailsSection';
 
 const WeeklyDetailsPage = () => {
-  const location = useLocation();
-  const searchParams = new URLSearchParams(location.search);
-  const date = searchParams.get('date') || '';
-  const week = searchParams.get('week') || '';
-  const observerRef = useRef<HTMLDivElement | null>(null);
-
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useGetWeeklyDetailsInfiniteQuery(date, week);
-  useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
-  const weeklyDetailsSummary = data?.pages?.flatMap(page => page.dailyDetails) || [];
-  const totalCount = data?.pages[0]?.countOfLogs ?? 0;
-  const isEmpty = weeklyDetailsSummary?.length === 0;
-
-  if (!data) return <div>로딩중..</div>;
-
   return (
     <div className="w-full min-h-screen flex flex-col">
       <DefaultHeader label="주별 상세내역" hasBackButton />
-      <TransactionSummary
-        period={data.pages[0].period}
-        income={data.pages[0].totalIncome}
-        expense={data.pages[0].totalExpense}
-        total={data.pages[0].totalAmount}
-        isWeekSummary
-      />
-      <div className={`w-full ${isEmpty && 'flex flex-grow items-center justify-center'}`}>
-        {isEmpty ? (
-          <span className="text-defaultGrey">내역이 없습니다</span>
-        ) : (
-          <>
-            <p className="w-full flex justify-end px-6 p-3.5">총 {totalCount}건</p>
-            <div className="flex flex-col gap-8">
-              {weeklyDetailsSummary.map(({ date, transactions }, indx) => (
-                <div className="w-full flex flex-col gap-3.5" key={indx}>
-                  <span className="pl-3">{format(date, 'MM.dd')}</span>
-                  <div className="w-full flex flex-col items-center gap-3">
-                    {transactions.map(transaction => (
-                      <TransactionDetailItem key={transaction.id} {...transaction} />
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </>
-        )}
-        <FetchingMessage isFetchingNextPage={isFetchingNextPage} />
-      </div>
-      {!isEmpty && <div ref={observerRef} className="h-4" />}
+      <WeeklyDetailsSection />
     </div>
   );
 };

--- a/src/pages/WeeklyDetailsPage/components/WeeklyDetailsSection.tsx
+++ b/src/pages/WeeklyDetailsPage/components/WeeklyDetailsSection.tsx
@@ -1,0 +1,71 @@
+import TransactionDetailItem from '@/components/detailItem/TransactionDetailItem';
+import FetchingMessage from '@/components/loading/FetchingMessage';
+import TransactionSummary from '@/components/summary/TransactionSummary';
+import { useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import useGetWeeklyDetailsInfiniteQuery from '@/hooks/apis/report/useGetWeeklyDetailsInfiniteQuery';
+import { format } from 'date-fns';
+import LoadingSpinner from '@/components/loading/LoadingSpinner';
+
+const WeeklyDetailsSection = () => {
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const date = searchParams.get('date') || '';
+  const week = searchParams.get('week') || '';
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } = useGetWeeklyDetailsInfiniteQuery(
+    date,
+    week,
+  );
+
+  useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
+  const weeklyDetailsSummary = data?.pages?.flatMap(page => page.dailyDetails) || [];
+  const totalCount = data?.pages[0]?.countOfLogs ?? 0;
+  const isEmpty = weeklyDetailsSummary?.length === 0;
+
+  if (!data || isPending)
+    return (
+      <div className="flex flex-col grow justify-center items-center">
+        <LoadingSpinner size={30} />
+      </div>
+    );
+
+  return (
+    <>
+      <TransactionSummary
+        period={data.pages[0].period}
+        income={data.pages[0].totalIncome}
+        expense={data.pages[0].totalExpense}
+        total={data.pages[0].totalAmount}
+        isWeekSummary
+      />
+      <div className={`w-full ${isEmpty && 'flex flex-grow items-center justify-center'}`}>
+        {isEmpty ? (
+          <span className="text-defaultGrey">내역이 없습니다</span>
+        ) : (
+          <>
+            <p className="w-full flex justify-end px-6 p-3.5">총 {totalCount}건</p>
+            <div className="flex flex-col gap-8">
+              {weeklyDetailsSummary.map(({ date, transactions }, indx) => (
+                <div className="w-full flex flex-col gap-3.5" key={indx}>
+                  <span className="pl-3">{format(date, 'MM.dd')}</span>
+                  <div className="w-full flex flex-col items-center gap-3">
+                    {transactions.map(transaction => (
+                      <TransactionDetailItem key={transaction.id} {...transaction} />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+        <FetchingMessage isFetchingNextPage={isFetchingNextPage} />
+      </div>
+      {!isEmpty && <div ref={observerRef} className="h-4" />}
+    </>
+  );
+};
+
+export default WeeklyDetailsSection;

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -35,7 +35,7 @@ export const baseSignupSchema = z.object({
     .min(1, { message: '값을 입력해주세요' })
     .max(10, { message: '최대 10자입니다' })
     .regex(nicknameRegex, '특수문자 X, 한글 또는 영문자로 시작돼야합니다'),
-  passwordConfirm: z.string().min(1, { message: '값을 입력해주세요' }),
+  passwordConfirm: z.string(),
   birth: z
     .string()
     .min(1, { message: '값을 입력해주세요' })
@@ -48,19 +48,23 @@ export const baseSignupSchema = z.object({
 
 export const signupSchema = passwordMatchRefinement(baseSignupSchema);
 
-export const profileSchema = baseSignupSchema.omit({
-  username: true,
-  password: true,
-  passwordConfirm: true,
-  verificationCode: true,
-  email: true,
-});
+export const profileSchema = baseSignupSchema
+  .omit({
+    username: true,
+    password: true,
+    passwordConfirm: true,
+    verificationCode: true,
+    email: true,
+  })
+  .extend({
+    isDefaultProfile: z.boolean(),
+  });
 
 export const changePasswordSchema = passwordMatchRefinement(
   z.object({
     currentPassword: passwordSchema,
     newPassword: passwordSchema,
-    passwordConfirm: z.string().min(1, { message: '값을 입력해주세요' }),
+    confirmNewPassword: z.string(),
   }),
 );
 

--- a/src/tests/pages/SignupPage.test.tsx
+++ b/src/tests/pages/SignupPage.test.tsx
@@ -11,6 +11,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import SignupPage from '@/pages/SignupPage/SignupPage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
 
 describe('SignupPage', () => {
   beforeEach(() => {
@@ -36,8 +37,6 @@ describe('SignupPage', () => {
   });
 
   test('필수 입력 요소 및 검증을 진행 했으면 버튼은 활성화 되어야한다.', async () => {
-    const submitButton = screen.getByRole('button', { name: /회원가입/i });
-
     // 1. 필수 필드 채우기
     const nameInput = screen.getByLabelText(/이름/i);
     fireEvent.change(nameInput, { target: { value: '홍길동' } });
@@ -55,10 +54,10 @@ describe('SignupPage', () => {
     fireEvent.click(usernameButton);
 
     const passwordInput = screen.getByTestId('password-input');
-    fireEvent.change(passwordInput, { target: { value: 'Password123!' } });
+    await userEvent.type(passwordInput, 'Password123!');
 
     const confirmPasswordInput = screen.getByTestId('confirm-password-input');
-    fireEvent.change(confirmPasswordInput, { target: { value: 'Password123!' } });
+    await userEvent.type(confirmPasswordInput, 'Password123!');
 
     const birthInput = screen.getByLabelText(/생년월일/i);
     fireEvent.change(birthInput, { target: { value: '1990-01-01' } });
@@ -72,7 +71,7 @@ describe('SignupPage', () => {
     fireEvent.click(screen.getAllByTestId('verify-button')[3]);
 
     await waitFor(() => {
-      expect(submitButton).toBeEnabled();
+      expect(screen.getByRole('button', { name: /회원가입/i })).toBeEnabled();
     });
   });
 });

--- a/src/types/chartTypes.ts
+++ b/src/types/chartTypes.ts
@@ -7,7 +7,7 @@ export type TickPayload = {
 export type ChartTotalAndSavingsType = {
   savingCategoryId: number;
   totalAmount: number;
-  totalSavingsAmount: number;
+  totalSaving: number;
 };
 
 export type AggregatedData = {

--- a/src/types/reportTypes.ts
+++ b/src/types/reportTypes.ts
@@ -11,7 +11,7 @@ export type OverviewLogType = {
 export type AnnualFinanceReportType = {
   yearTotalIncome: number;
   yearTotalExpense: number;
-  yearTotalBalance: number;
+  yearTotalAmount: number;
   monthlyLogs: OverviewLogType[];
 };
 

--- a/src/utils/invalidateTransactionQueries.ts
+++ b/src/utils/invalidateTransactionQueries.ts
@@ -6,6 +6,7 @@ const invalidateTransactionQueries = (queryClient: QueryClient, date: Date) => {
   const yearMonth = format(date, 'yyyy-MM');
   const yearMonthDay = format(date, 'yyyy-MM-dd');
 
+  // 월별/일별 데이터 조회관련 쿼리키
   queryClient.invalidateQueries({
     queryKey: ['dailyDetails', yearMonthDay],
   });
@@ -13,11 +14,35 @@ const invalidateTransactionQueries = (queryClient: QueryClient, date: Date) => {
     queryKey: ['monthlyTotal', yearMonth],
   });
 
+  // 월별/주별 데이터 조회관련 쿼리키
   queryClient.invalidateQueries({
     queryKey: ['yearlySummary', year],
   });
   queryClient.invalidateQueries({
     queryKey: ['weeklySummary', yearMonth],
+  });
+  queryClient.invalidateQueries({
+    queryKey: ['weeklyDetails', yearMonth],
+  });
+
+  // 차트 데이터 조회관련 쿼리키
+  queryClient.invalidateQueries({
+    queryKey: ['barChart', year],
+  });
+  queryClient.invalidateQueries({
+    queryKey: ['barChart', yearMonth],
+  });
+  queryClient.invalidateQueries({
+    queryKey: ['stackedBarChart', year],
+  });
+  queryClient.invalidateQueries({
+    queryKey: ['stackedBarChart', yearMonth],
+  });
+  queryClient.invalidateQueries({
+    queryKey: ['totalAndSavings', year],
+  });
+  queryClient.invalidateQueries({
+    queryKey: ['totalAndSavings', yearMonth],
   });
 };
 

--- a/src/utils/invalidateTransactionQueries.ts
+++ b/src/utils/invalidateTransactionQueries.ts
@@ -1,0 +1,24 @@
+import { QueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns';
+
+const invalidateTransactionQueries = (queryClient: QueryClient, date: Date) => {
+  const year = format(date, 'yyyy');
+  const yearMonth = format(date, 'yyyy-MM');
+  const yearMonthDay = format(date, 'yyyy-MM-dd');
+
+  queryClient.invalidateQueries({
+    queryKey: ['dailyDetails', yearMonthDay],
+  });
+  queryClient.invalidateQueries({
+    queryKey: ['monthlyTotal', yearMonth],
+  });
+
+  queryClient.invalidateQueries({
+    queryKey: ['yearlySummary', year],
+  });
+  queryClient.invalidateQueries({
+    queryKey: ['weeklySummary', yearMonth],
+  });
+};
+
+export default invalidateTransactionQueries;

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,15 +1,19 @@
 import { z } from 'zod';
 
-export const passwordMatchRefinement = <T extends { passwordConfirm: string; newPassword?: string; password?: string }>(
+export const passwordMatchRefinement = <
+  T extends { passwordConfirm?: string; confirmNewPassword?: string; newPassword?: string; password?: string },
+>(
   schema: z.ZodType<T>,
 ) =>
-  schema.refine(
-    data => {
-      const password = data.password ?? data.newPassword; // signup과 changePassword 둘 다 대응
-      return password === data.passwordConfirm;
-    },
-    {
-      message: '비밀번호가 일치하지 않습니다', // 검증 실패 시 출력되는 메시지
-      path: ['passwordConfirm'], // 에러를 표시할 필드
-    },
-  );
+  schema.superRefine((data, ctx) => {
+    const password = data.password ?? data.newPassword;
+    const confirm = data.passwordConfirm ?? data.confirmNewPassword;
+
+    if (password !== confirm) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '비밀번호가 일치하지 않습니다',
+        path: data.passwordConfirm !== undefined ? ['passwordConfirm'] : ['confirmNewPassword'],
+      });
+    }
+  });


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
## [ 페이지 로딩 처리 ]
- 가계부 편집 페이지
  - [x] 가계부 조회 로딩 처리
  - [x] 활성화 된 카테고리 조회 로딩 처리   

- 월별/주별 페이지
  - [x] 월별 수입/지출 명세 조회 로딩 처리
  - [x] 주별 수입/지출 명세 조회 로딩 처리

- 주별 상세 페이지 
  - [x] 주별 상세 내역 조회 로딩 처리

- 차트 페이지
  - [x] 지출, 수입 총 금액 조회 로딩  처리
  - [x] 지출, 수입  카테고리 차트 로딩 처리
  - [x] 지출, 수입 막대그래프 로딩 처리

- 카테고리 차트 상세 페이지
  - [x] 카테고리 상세 차트 로딩 처리
  - [x] 카테고리 구간 내역 조회 로딩 처리 

- 환경 설정 페이지
  - [x] 프로필 편집 데이터 조회 로딩 처리
  - [x] 프로필 편집 로딩 처리
  - [x] 회원탈퇴 로딩 처리
  - [x] 로그아웃 로딩 처리 
  - [x] 전체 데이터 초기화 로딩 처리
  - [x] 반복 데이터 조회 로딩 처리

## [ 수정 사항  ]
1. useFilteredCategories 로직 수정
2. invalidateTransactionQueries: 가계부 데이터와 관련 된 쿼리 키 만료 로직 util 함수 생성 
3. SelectBox 컴포넌트 에러메세지 추가
4. 차트 관련 수정 사항
    - radius 조건 수정
    - PeriodComparisonChart에  customXAxisTick 추가 : 기간별 날짜를 클릭했을 때 클릭 이벤트가 실행 되도록 하기위해 추가
5. 프로필 편집 시 isDefaultImage 필드 필수로 포함 되도록 수정
6. 비밀 번호 재확인 검증 로직 수정
7. 구글 폼 추가