### PR TITLE
Hotfix: 무한 스크롤 조회하고 재조회시 cursor 데이터가 모두 조회 되는 오류

### DIFF
--- a/src/api/services/transactionService.ts
+++ b/src/api/services/transactionService.ts
@@ -4,9 +4,11 @@ import {
   AddTransactionRes,
   DailyTransactionType,
   DeleteTransactionReq,
+  DeleteTransactionRes,
   IterationDataType,
   MonthlyTotalTransactionType,
   TransactionFormDataType,
+  UpdateTransactionRes,
 } from '@/types/transactionTypes';
 
 export const getMonthlyTotal = async (date: string) => {
@@ -49,22 +51,38 @@ export const getIncomeTransaction = async (id: string) => {
 };
 
 export const updateExpenseTransaction = async (id: string, body: TransactionFormDataType) => {
-  const res = await fetchData<TransactionFormDataType>('PUT', endpoints.transaction.updateExpense(id), body);
+  const res = await fetchData<TransactionFormDataType, UpdateTransactionRes>(
+    'PUT',
+    endpoints.transaction.updateExpense(id),
+    body,
+  );
   return res;
 };
 
 export const updateIncomeTransaction = async (id: string, body: TransactionFormDataType) => {
-  const res = await fetchData<TransactionFormDataType>('PUT', endpoints.transaction.updateIncome(id), body);
+  const res = await fetchData<TransactionFormDataType, UpdateTransactionRes>(
+    'PUT',
+    endpoints.transaction.updateIncome(id),
+    body,
+  );
   return res;
 };
 
 export const deleteExpenseTransaction = async ({ id, body }: { id: string; body?: DeleteTransactionReq }) => {
-  const res = await fetchData<DeleteTransactionReq>('DELETE', endpoints.transaction.deleteExpense(id), body);
+  const res = await fetchData<DeleteTransactionReq, DeleteTransactionRes>(
+    'DELETE',
+    endpoints.transaction.deleteExpense(id),
+    body,
+  );
   return res;
 };
 
 export const deleteIncomeTransaction = async ({ id, body }: { id: string; body?: DeleteTransactionReq }) => {
-  const res = await fetchData<DeleteTransactionReq>('DELETE', endpoints.transaction.deleteIncome(id), body);
+  const res = await fetchData<DeleteTransactionReq, DeleteTransactionRes>(
+    'DELETE',
+    endpoints.transaction.deleteIncome(id),
+    body,
+  );
   return res;
 };
 

--- a/src/hooks/apis/chart/useCategoryLogsInfiniteQuery.ts
+++ b/src/hooks/apis/chart/useCategoryLogsInfiniteQuery.ts
@@ -9,6 +9,8 @@ const useCategoryLogsInfiniteQuery = (categoryId: string, date: string) => {
     initialPageParam: null,
     getNextPageParam: lastPage => (lastPage.hasNext ? lastPage.nextCursor : undefined),
     enabled: !!categoryId && !!date,
+    staleTime: Infinity,
+    refetchOnMount: false,
   });
 };
 

--- a/src/hooks/apis/report/useGetWeeklyDetailsInfiniteQuery.ts
+++ b/src/hooks/apis/report/useGetWeeklyDetailsInfiniteQuery.ts
@@ -15,8 +15,8 @@ const useGetWeeklyDetailsInfiniteQuery = (date: string, week: string) => {
     initialPageParam: null,
     getNextPageParam: lastPage => (lastPage.hasNext ? lastPage.nextCursor : undefined),
     enabled: !!week && !!date,
-    staleTime: 10 * 60 * 1000,
-    gcTime: 15 * 60 * 1000,
+    staleTime: Infinity,
+    refetchOnMount: false,
   });
 };
 

--- a/src/hooks/apis/transaction/useAddTransaction.ts
+++ b/src/hooks/apis/transaction/useAddTransaction.ts
@@ -24,7 +24,7 @@ const useAddTransaction = ({ type, setError }: Props) => {
     mutationFn: (body: TransactionFormDataType) => mutationFn(body),
     onSuccess: data => {
       useDraftStore.getState().disableSave();
-      invalidateTransactionQueries(queryClient, calenderDate);
+      invalidateTransactionQueries(queryClient, calenderDate, data.data?.categoryId);
       sessionStorage.setItem('selected-id', String(data.data?.id));
       sessionStorage.removeItem('transaction-form-data');
       navigate('/');

--- a/src/hooks/apis/transaction/useDeleteTransaction.ts
+++ b/src/hooks/apis/transaction/useDeleteTransaction.ts
@@ -16,9 +16,9 @@ const useDeleteTransaction = (type: IncomeExpenseType) => {
 
   return useMutation({
     mutationFn: ({ id, body }: { id: string; body?: DeleteTransactionReq }) => mutationFn({ id, body }),
-    onSuccess: () => {
+    onSuccess: data => {
       useDraftStore.getState().disableSave();
-      invalidateTransactionQueries(queryClient, calenderDate);
+      invalidateTransactionQueries(queryClient, calenderDate, data.data?.categoryId);
       sessionStorage.removeItem('transaction-form-data');
       navigate(-1);
     },

--- a/src/hooks/apis/transaction/useUpdateTransaction.ts
+++ b/src/hooks/apis/transaction/useUpdateTransaction.ts
@@ -22,9 +22,9 @@ const useUpdateTransaction = ({
 
   return useMutation({
     mutationFn: ({ id, body }: { id: string; body: TransactionFormDataType }) => mutationFn(id, body),
-    onSuccess: () => {
+    onSuccess: data => {
       useDraftStore.getState().disableSave();
-      invalidateTransactionQueries(queryClient, calenderDate);
+      invalidateTransactionQueries(queryClient, calenderDate, data.data?.categoryId);
       sessionStorage.removeItem('transaction-form-data');
       navigate(-1);
     },

--- a/src/hooks/useScrollToSelectedRef.ts
+++ b/src/hooks/useScrollToSelectedRef.ts
@@ -7,12 +7,12 @@ const useScrollToSelectedRef = (type: 'period' | 'id' | 'category', deps?: Trans
 
   useEffect(() => {
     if (selectedRef.current) {
-      selectedRef.current.scrollIntoView({ behavior: 'auto', block: 'center' });
+      selectedRef.current.scrollIntoView({ behavior: 'instant', block: 'center' });
     }
 
     const timeout = setTimeout(() => {
       sessionStorage.removeItem(`selected-${type}`);
-    }, 500);
+    }, 300);
 
     return () => clearTimeout(timeout);
   }, [deps, type]);

--- a/src/hooks/useScrollToSelectedRef.ts
+++ b/src/hooks/useScrollToSelectedRef.ts
@@ -12,7 +12,7 @@ const useScrollToSelectedRef = (type: 'period' | 'id' | 'category', deps?: Trans
 
     const timeout = setTimeout(() => {
       sessionStorage.removeItem(`selected-${type}`);
-    }, 300);
+    }, 500);
 
     return () => clearTimeout(timeout);
   }, [deps, type]);

--- a/src/pages/CategoryDetailsPage/components/Log/CategoryLogListSection.tsx
+++ b/src/pages/CategoryDetailsPage/components/Log/CategoryLogListSection.tsx
@@ -20,6 +20,7 @@ const CategoryLogListSection = ({ transactionType, categoryId, date, isSavings }
     date,
   );
   useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
+
   const allCategoryLogs = data?.pages?.flatMap(page => page.categoryLogs) || [];
   const totalCount = data?.pages[0]?.countOfLogs ?? 0;
   const isEmpty = allCategoryLogs?.length === 0;

--- a/src/types/transactionTypes.ts
+++ b/src/types/transactionTypes.ts
@@ -40,9 +40,18 @@ export type IterationDataType = {
 
 export type AddTransactionRes = {
   id: number;
+  categoryId: number;
 };
 
 export type DeleteTransactionReq = { iterationAction?: IterationActionEnumType };
+
+export type DeleteTransactionRes = {
+  categoryId: number;
+};
+
+export type UpdateTransactionRes = {
+  categoryId: number;
+};
 
 export type IncomeExpenseType = '지출' | '수입';
 

--- a/src/utils/invalidateTransactionQueries.ts
+++ b/src/utils/invalidateTransactionQueries.ts
@@ -30,7 +30,7 @@ const invalidateTransactionQueries = (queryClient: QueryClient, date: Date, cate
   queryClient.invalidateQueries({
     queryKey: ['weeklySummary'],
   });
-  queryClient.invalidateQueries({
+  queryClient.refetchQueries({
     queryKey: ['weeklyDetails'],
   });
 

--- a/src/utils/invalidateTransactionQueries.ts
+++ b/src/utils/invalidateTransactionQueries.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 
-const invalidateTransactionQueries = (queryClient: QueryClient, date: Date) => {
+const invalidateTransactionQueries = (queryClient: QueryClient, date: Date, categoryId?: number) => {
   const year = format(date, 'yyyy');
   const yearMonth = format(date, 'yyyy-MM');
   const yearMonthDay = format(date, 'yyyy-MM-dd');
@@ -21,49 +21,31 @@ const invalidateTransactionQueries = (queryClient: QueryClient, date: Date) => {
   });
 
   // 월별/주별 데이터 조회관련 쿼리키
+  queryClient.invalidateQueries({
+    queryKey: ['yearlySummary'],
+  });
   queryClient.refetchQueries({
     queryKey: ['yearlySummary', year],
   });
   queryClient.invalidateQueries({
     queryKey: ['weeklySummary'],
   });
-  queryClient.refetchQueries({
-    queryKey: ['weeklySummary', yearMonth],
-  });
   queryClient.invalidateQueries({
     queryKey: ['weeklyDetails'],
-  });
-  queryClient.refetchQueries({
-    queryKey: ['weeklyDetails', yearMonth],
   });
 
   // 차트 데이터 조회관련 쿼리키
   queryClient.invalidateQueries({
     queryKey: ['barChart'],
   });
-  queryClient.refetchQueries({
-    queryKey: ['barChart', year],
-  });
-  queryClient.refetchQueries({
-    queryKey: ['barChart', yearMonth],
-  });
   queryClient.invalidateQueries({
     queryKey: ['stackedBarChart'],
-  });
-  queryClient.refetchQueries({
-    queryKey: ['stackedBarChart', year],
-  });
-  queryClient.refetchQueries({
-    queryKey: ['stackedBarChart', yearMonth],
   });
   queryClient.invalidateQueries({
     queryKey: ['totalAndSavings'],
   });
   queryClient.refetchQueries({
-    queryKey: ['totalAndSavings', year],
-  });
-  queryClient.refetchQueries({
-    queryKey: ['totalAndSavings', yearMonth],
+    queryKey: ['categoryLogs', categoryId],
   });
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#103

## 📝작업 내용

Q) 문제: 무한 스크롤이 적용 된 페이지를 최초로 조회 하고 다시 그 페이지를 조회했을 때 이전에 조회 했던 cursor 까지의 데이터가 한번에 불러와지는 문제 발생

- react-qeury에 캐시 된 pages 데이터에 의해 `fetchNextPage` 가 실행 되어서 발생하는 문제라고 추정됨

A) 해결: `useInfiniteQuery`에 `refetchOnMount: false` 옵션을 설정해줘서 마운트되어도 refetch를 유발하지 않도록 설정해줌