### PR TITLE
Hotfix : QA 오류 수정

### DIFF
--- a/src/api/services/authService.ts
+++ b/src/api/services/authService.ts
@@ -11,7 +11,7 @@ import {
   ProfileFormData,
   ChangePasswordData,
   GetUserEmailRes,
-  EmailChangeData,
+  ChangeUserEmailReq,
 } from '@/types/authTypes';
 import { tokenManager } from '@/utils/tokenManager';
 
@@ -48,8 +48,8 @@ export const getUserEmail = async () => {
   return res.data?.email;
 };
 
-export const changeEmail = async (body: EmailChangeData) => {
-  const res = await fetchData<EmailChangeData, undefined>('PUT', endpoints.email.changeEmail, body);
+export const changeEmail = async (body: ChangeUserEmailReq) => {
+  const res = await fetchData<ChangeUserEmailReq, undefined>('PUT', endpoints.email.changeEmail, body);
   return res;
 };
 

--- a/src/api/services/authService.ts
+++ b/src/api/services/authService.ts
@@ -11,7 +11,7 @@ import {
   ProfileFormData,
   ChangePasswordData,
   GetUserEmailRes,
-  ChangeEmailReq,
+  EmailChangeData,
 } from '@/types/authTypes';
 import { tokenManager } from '@/utils/tokenManager';
 
@@ -48,8 +48,8 @@ export const getUserEmail = async () => {
   return res.data?.email;
 };
 
-export const changeEmail = async (body: ChangeEmailReq) => {
-  const res = await fetchData<ChangeEmailReq, undefined>('PUT', endpoints.email.changeEmail, body);
+export const changeEmail = async (body: EmailChangeData) => {
+  const res = await fetchData<EmailChangeData, undefined>('PUT', endpoints.email.changeEmail, body);
   return res;
 };
 

--- a/src/components/error/FetchErrorBoundary.tsx
+++ b/src/components/error/FetchErrorBoundary.tsx
@@ -1,13 +1,11 @@
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { isFetchError } from '@/utils/error/isFetchError';
 import { getFetchFallbackByStatus } from '@/components/error/getFetchFallbackByStatus';
-import { IoIosWarning } from 'react-icons/io';
 
 const FetchFallback = ({ error }: FallbackProps) => {
   if (isFetchError(error)) {
     return (
       <div className="w-full grow flex flex-col justify-center items-center gap-3.5 p-5">
-        <IoIosWarning size={80} color="red" />
         {getFetchFallbackByStatus(error)}
       </div>
     );

--- a/src/components/input/PrimaryInput.tsx
+++ b/src/components/input/PrimaryInput.tsx
@@ -4,9 +4,14 @@ import { clsx } from 'clsx';
 import CheckIcon from '@/components/icon/CheckIcon';
 import { FieldError, FieldErrorsImpl, Merge } from 'react-hook-form';
 import { VerifyButtonType } from '@/types/fieldType';
+import { FaRegEye } from 'react-icons/fa';
+import { FaRegEyeSlash } from 'react-icons/fa';
 
 interface PrimaryInputProps {
   label: string;
+  isPassword?: boolean;
+  isPasswordVisible?: boolean;
+  handleVisibleClick?: () => void;
   isRequired?: boolean;
   isPending?: boolean;
   hasCheckIcon?: boolean;
@@ -21,6 +26,9 @@ const PrimaryInput = forwardRef<HTMLInputElement, PrimaryInputProps & React.Inpu
   (
     {
       label,
+      isPassword,
+      isPasswordVisible,
+      handleVisibleClick,
       isRequired,
       isPending,
       hasCheckIcon,
@@ -64,6 +72,14 @@ const PrimaryInput = forwardRef<HTMLInputElement, PrimaryInputProps & React.Inpu
                 <span className="absolute top-1/2 -translate-y-1/2 right-3">
                   <CheckIcon color="#a1c377" />
                 </span>
+              )}
+              {isPassword && (
+                <button
+                  type="button"
+                  onClick={handleVisibleClick}
+                  className="absolute top-1/2 -translate-y-1/2 right-5 text-gray-500 cursor-pointer">
+                  {isPasswordVisible ? <FaRegEyeSlash size={15} /> : <FaRegEye size={15} />}
+                </button>
               )}
             </div>
             {buttonLabel && (

--- a/src/components/input/auth/PasswordField.tsx
+++ b/src/components/input/auth/PasswordField.tsx
@@ -1,5 +1,5 @@
 import PrimaryInput from '@/components/input/PrimaryInput';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 const PasswordField = () => {
@@ -9,6 +9,11 @@ const PasswordField = () => {
     register,
     formState: { errors },
   } = useFormContext();
+  const [isVisible, setIsVisible] = useState(false);
+
+  const handleVisibleClick = () => {
+    setIsVisible(prev => !prev);
+  };
 
   useEffect(() => {
     const subscription = watch((_, { name }) => {
@@ -27,8 +32,11 @@ const PasswordField = () => {
         data-testid="password-input"
         label="비밀번호"
         isRequired
-        type="password"
+        type={isVisible ? 'text' : 'password'}
         errorMessage={errors.password?.message}
+        isPassword
+        isPasswordVisible={isVisible}
+        handleVisibleClick={handleVisibleClick}
       />
       <PrimaryInput
         {...register('passwordConfirm')}

--- a/src/hooks/apis/category/useDeleteCategory.ts
+++ b/src/hooks/apis/category/useDeleteCategory.ts
@@ -3,7 +3,7 @@ import { IncomeExpenseType } from '@/types/transactionTypes';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 
-const useDeleteCategory = (type: IncomeExpenseType) => {
+const useDeleteCategory = (type: IncomeExpenseType, closeModal: () => void) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -16,6 +16,7 @@ const useDeleteCategory = (type: IncomeExpenseType) => {
         queryKey: [`activeCategories`, type === '수입' ? 'income' : 'expense'],
       });
       toast.success(data.message);
+      closeModal();
     },
   });
 };

--- a/src/hooks/apis/category/useDeleteCategory.ts
+++ b/src/hooks/apis/category/useDeleteCategory.ts
@@ -3,7 +3,7 @@ import { IncomeExpenseType } from '@/types/transactionTypes';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 
-const useDeleteCategory = (type: IncomeExpenseType, closeModal: () => void) => {
+const useDeleteCategory = (type: IncomeExpenseType, closeModal?: () => void) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -16,7 +16,7 @@ const useDeleteCategory = (type: IncomeExpenseType, closeModal: () => void) => {
         queryKey: [`activeCategories`, type === '수입' ? 'income' : 'expense'],
       });
       toast.success(data.message);
-      closeModal();
+      if (closeModal) closeModal();
     },
   });
 };

--- a/src/hooks/apis/transaction/useGetTransaction.ts
+++ b/src/hooks/apis/transaction/useGetTransaction.ts
@@ -8,6 +8,9 @@ const useGetTransaction = (type: IncomeExpenseType, id: string, enabled: boolean
   return useQuery({
     queryKey: ['transaction', type, id],
     queryFn: () => queryFn(id),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    refetchOnMount: false,
     enabled: enabled,
   });
 };

--- a/src/hooks/category/useCategoryManagement.ts
+++ b/src/hooks/category/useCategoryManagement.ts
@@ -1,5 +1,5 @@
 import useModal from '@/hooks/useModal';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { IncomeExpenseType } from '@/types/transactionTypes';
 import useDeleteCategory from '@/hooks/apis/category/useDeleteCategory';
 import { useLocation } from 'react-router-dom';
@@ -13,7 +13,7 @@ export const useCategoryManagement = () => {
   const queryParams = new URLSearchParams(location.search);
   const type = queryParams.get('type') as IncomeExpenseType;
 
-  const { mutate: deleteCategory, isSuccess, isPending: isDeletePending } = useDeleteCategory(type);
+  const { mutate: deleteCategory, isPending: isDeletePending } = useDeleteCategory(type, closeModal);
 
   const handleDeleteIconClick = (id: number, name: string) => {
     categoryRef.current = { name, id };
@@ -23,12 +23,6 @@ export const useCategoryManagement = () => {
   const handleDeleteCategory = (id: number) => {
     deleteCategory(id.toString());
   };
-
-  useEffect(() => {
-    if (isSuccess) {
-      closeModal();
-    }
-  }, [isSuccess, closeModal]);
 
   return {
     type,

--- a/src/hooks/signup/useSignupForm.ts
+++ b/src/hooks/signup/useSignupForm.ts
@@ -3,7 +3,7 @@ import { SignupFormType } from '@/types/authTypes';
 import { useEmailFieldStore } from '@/stores/fields/useEmailFieldStore';
 import { useNicknameFieldStore } from '@/stores/fields/useNicknameFieldStore';
 import { useUsernameFieldStore } from '@/stores/fields/useUsernameFieldStore';
-import { filteredData } from '@/utils/filteredFormData';
+import { filteredData } from '@/utils/form/filteredFormData';
 import { omit } from 'lodash';
 import useSignup from '@/hooks/apis/auth/useSignup';
 

--- a/src/hooks/transaction/useTransactionDraft.ts
+++ b/src/hooks/transaction/useTransactionDraft.ts
@@ -8,8 +8,9 @@ const useTransactionDraft = () => {
   const {
     watch,
     reset,
-    formState: { isDirty },
+    formState: { dirtyFields },
   } = useFormContext<TransactionFormDataType>();
+  const isChanged = Object.keys(dirtyFields).length > 0;
   const { shouldSave, enableSave } = useDraftStore();
   const formData = watch();
   const [searchParams] = useSearchParams();
@@ -31,8 +32,10 @@ const useTransactionDraft = () => {
 
   useEffect(() => {
     if (!shouldSave) return;
-    if (isDirty) sessionStorage.setItem('transaction-form-data', JSON.stringify(formData));
-  }, [formData, shouldSave, isDirty]);
+    if (isChanged) {
+      sessionStorage.setItem('transaction-form-data', JSON.stringify(formData));
+    }
+  }, [formData, shouldSave, isChanged]);
 
   useEffect(() => {
     return () => {

--- a/src/hooks/transaction/useTransactionDraft.ts
+++ b/src/hooks/transaction/useTransactionDraft.ts
@@ -1,18 +1,18 @@
+import { useDraftMetaStore } from '@/stores/useDraftMetaStore';
 import { useDraftStore } from '@/stores/useDraftStore';
 import { TransactionFormDataType } from '@/types/transactionTypes';
 import { useEffect } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { useSearchParams } from 'react-router-dom';
 
 const useTransactionDraft = () => {
   const {
-    watch,
     reset,
-    formState: { dirtyFields },
+    formState: { isDirty },
   } = useFormContext<TransactionFormDataType>();
-  const isChanged = Object.keys(dirtyFields).length > 0;
+  const { setHasDraftData } = useDraftMetaStore();
   const { shouldSave, enableSave } = useDraftStore();
-  const formData = watch();
+  const formData = useWatch();
   const [searchParams] = useSearchParams();
   const queryDate = searchParams.get('date');
 
@@ -26,21 +26,24 @@ const useTransactionDraft = () => {
         reset(parsed);
       } else {
         sessionStorage.removeItem('transaction-form-data');
+        setHasDraftData(false);
       }
     }
-  }, [reset, queryDate]);
+  }, [reset, queryDate, setHasDraftData]);
 
   useEffect(() => {
-    if (!shouldSave) return;
-    if (isChanged) {
-      sessionStorage.setItem('transaction-form-data', JSON.stringify(formData));
+    if (!shouldSave) {
+      setHasDraftData(false);
+      return;
     }
-  }, [formData, shouldSave, isChanged]);
+    if (isDirty) {
+      sessionStorage.setItem('transaction-form-data', JSON.stringify(formData));
+      setHasDraftData(true);
+    }
+  }, [formData, shouldSave, isDirty, setHasDraftData]);
 
   useEffect(() => {
-    return () => {
-      enableSave();
-    };
+    enableSave();
   }, [enableSave]);
 };
 

--- a/src/hooks/transaction/useTransactionForm.ts
+++ b/src/hooks/transaction/useTransactionForm.ts
@@ -72,6 +72,7 @@ const useTransactionForm = ({ transactionType, initialIterationTypeRef }: Props)
   }, [transactionFormData, categoryOptions, setValue]);
 
   return {
+    transactionFormData,
     categoryOptions,
     isGetTransactionFetching,
     isCategoryPending,

--- a/src/hooks/transaction/useTransactionParams.ts
+++ b/src/hooks/transaction/useTransactionParams.ts
@@ -1,3 +1,4 @@
+import { IncomeExpenseType } from '@/types/transactionTypes';
 import { useLocation } from 'react-router-dom';
 
 const useTransactionParams = () => {
@@ -5,7 +6,7 @@ const useTransactionParams = () => {
   const queryParams = new URLSearchParams(location.search);
   const pageType = queryParams.get('type');
   const transactionDate = queryParams.get('date');
-  const transactionMode = queryParams.get('transactionType');
+  const transactionMode = queryParams.get('transactionType') as IncomeExpenseType;
   const transactionId = pageType ? queryParams.get('id') : '';
   const isEditPage = pageType === 'edit';
 

--- a/src/pages/AddEditTransactionPage/AddEditTransactionPage.tsx
+++ b/src/pages/AddEditTransactionPage/AddEditTransactionPage.tsx
@@ -34,6 +34,7 @@ const AddEditTransactionPage = () => {
     mode: 'onChange',
   });
 
+  const isIterationModifiedRef = useRef<boolean>(false);
   const initialIterationTypeRef = useRef(methods.getValues('iterationType'));
   const dateRef = useRef(methods.getValues('date'));
 
@@ -57,7 +58,11 @@ const AddEditTransactionPage = () => {
       <PageErrorBoundary>
         <FetchErrorBoundary>
           <FormProvider {...methods}>
-            <TransactionForm openEdit={openEdit} initialIterationTypeRef={initialIterationTypeRef} />
+            <TransactionForm
+              openEdit={openEdit}
+              initialIterationTypeRef={initialIterationTypeRef}
+              isIterationModifiedRef={isIterationModifiedRef}
+            />
             {isDeleteModalOpen &&
               (initialIterationTypeRef.current === 'none' ? (
                 <DefaultModal
@@ -71,7 +76,7 @@ const AddEditTransactionPage = () => {
                 <IterationChangeModal type="delete" onClose={closeDeleteModal} />
               ))}
             {isEditOpen && initialIterationTypeRef.current !== 'none' && (
-              <IterationChangeModal type="edit" onClose={closeEdit} />
+              <IterationChangeModal type="edit" onClose={closeEdit} isIterationModifiedRef={isIterationModifiedRef} />
             )}
           </FormProvider>
         </FetchErrorBoundary>

--- a/src/pages/AddEditTransactionPage/components/TransactionFields.tsx
+++ b/src/pages/AddEditTransactionPage/components/TransactionFields.tsx
@@ -1,6 +1,7 @@
 import PrimaryInput from '@/components/input/PrimaryInput';
 import SelectBox from '@/components/input/SelectBox';
 import { EXPENSE_METHODS } from '@/constants/options';
+import { useResetCustomIteration } from '@/hooks/useResetCustomIteration';
 import MemoInput from '@/pages/AddEditTransactionPage/components/MemoInput';
 import { useCalenderDateStore } from '@/stores/useCalenderDateStore';
 import { useHeaderDateStore } from '@/stores/useHeaderDateStore';
@@ -21,6 +22,7 @@ const TransactionFields = ({ type, options }: Props) => {
   const isExpense = type === '지출';
   const { setMainHeaderDate } = useHeaderDateStore();
   const { setCalenderDate } = useCalenderDateStore();
+  const { customIteration } = useResetCustomIteration();
   const {
     control,
     register,
@@ -41,6 +43,10 @@ const TransactionFields = ({ type, options }: Props) => {
     setCalenderDate(currentDate);
     setMainHeaderDate(currentDate);
 
+    const { customIteration: prevCustomIteration } = getValues();
+    const newDaysOfWeek =
+      prevCustomIteration?.iterationRule.type === 'weekly' ? prevCustomIteration.iterationRule.daysOfWeek : [koreanDay];
+
     const newCustomIteration = {
       end: {
         date: format(addMonths(currentDate, 2), 'yyyy-MM-dd'),
@@ -51,12 +57,13 @@ const TransactionFields = ({ type, options }: Props) => {
           week: getKoreanWeekOfMonth(currentDate),
           dayOfWeek: koreanDay,
         },
-
-        daysOfWeek: [koreanDay],
+        daysOfWeek: [...newDaysOfWeek],
       },
     };
-    const { customIteration: prevCustomIteration } = getValues();
-    const merged = merge({}, prevCustomIteration, newCustomIteration);
+
+    const merged = prevCustomIteration
+      ? merge({}, prevCustomIteration, newCustomIteration)
+      : merge({}, customIteration, newCustomIteration);
 
     setValue('date', format(currentDate, 'yyyy-MM-dd'), { shouldDirty: true });
     setValue('customIteration', merged, { shouldDirty: true });

--- a/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
+++ b/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
@@ -53,7 +53,8 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
     initialIterationTypeRef,
   });
   useTransactionDraft();
-  const isChanged = Object.keys(dirtyFields).length > 0;
+  const daftData = sessionStorage.getItem('transaction-form-data') || '';
+  const hasDraftData = Boolean(daftData);
 
   const onSubmit = (data: TransactionFormDataType) => {
     const isIncome = transactionType === '수입';
@@ -107,7 +108,7 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
           data-testid="submit-button"
           label="저장"
           type="submit"
-          disabled={!isValid || !isChanged}
+          disabled={!isValid || !hasDraftData}
           isPending={isAddPending || isUpdatePending}
         />
       </div>

--- a/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
+++ b/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
@@ -13,25 +13,27 @@ import IterationCycleModal from '@/pages/AddEditTransactionPage/components/modal
 import CustomIterationModal from '@/pages/AddEditTransactionPage/components/modals/custom/CustomIterationModal';
 import useModal from '@/hooks/useModal';
 import useUpdateTransaction from '@/hooks/apis/transaction/useUpdateTransaction';
-import { getFinalData } from '@/pages/AddEditTransactionPage/utils/filterTransactionForm';
+import { getFinalData } from '@/utils/form/filterTransactionForm';
 import LoadingSpinner from '@/components/loading/LoadingSpinner';
 import { LOADING_OPTIONS } from '@/constants/options';
 import useTransactionDraft from '@/hooks/transaction/useTransactionDraft';
 import { useDraftMetaStore } from '@/stores/useDraftMetaStore';
+import { hasIterationChanged } from '@/utils/form/hasIterationChanged';
 
 interface Props {
   openEdit: () => void;
   initialIterationTypeRef: React.MutableRefObject<string>;
+  isIterationModifiedRef: React.MutableRefObject<boolean>;
 }
 
-const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
+const TransactionForm = ({ openEdit, initialIterationTypeRef, isIterationModifiedRef }: Props) => {
   const {
     handleSubmit,
     setValue,
     getValues,
     setError,
     watch,
-    formState: { isValid, dirtyFields },
+    formState: { isValid },
   } = useFormContext<TransactionFormDataType>();
   const { isEditPage, transactionId } = useTransactionParams();
   const transactionType = watch('transactionType') as IncomeExpenseType;
@@ -47,6 +49,7 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
     setError,
   });
   const {
+    transactionFormData,
     categoryOptions: options,
     isGetTransactionFetching,
     isCategoryPending,
@@ -58,7 +61,8 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
 
   const onSubmit = (data: TransactionFormDataType) => {
     const isIncome = transactionType === '수입';
-    const isIterationModified = Boolean(dirtyFields.iterationType) || Boolean(dirtyFields.customIteration);
+    const isIterationModified = hasIterationChanged(transactionFormData, data);
+    isIterationModifiedRef.current = isIterationModified;
 
     let body = getFinalData(data, isIncome);
 

--- a/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
+++ b/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
@@ -17,6 +17,7 @@ import { getFinalData } from '@/pages/AddEditTransactionPage/utils/filterTransac
 import LoadingSpinner from '@/components/loading/LoadingSpinner';
 import { LOADING_OPTIONS } from '@/constants/options';
 import useTransactionDraft from '@/hooks/transaction/useTransactionDraft';
+import { useDraftMetaStore } from '@/stores/useDraftMetaStore';
 
 interface Props {
   openEdit: () => void;
@@ -35,6 +36,7 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
   const { isEditPage, transactionId } = useTransactionParams();
   const transactionType = watch('transactionType') as IncomeExpenseType;
   const [backupCustomIteration, setBackupCustomIteration] = useState<CustomIterationType | null>(null);
+  const { hasDraftData } = useDraftMetaStore();
 
   const { isOpen, openModal, closeModal } = useModal();
   const { isOpen: isCustomOpen, openModal: openCustom, closeModal: closeCustom } = useModal();
@@ -53,12 +55,10 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef }: Props) => {
     initialIterationTypeRef,
   });
   useTransactionDraft();
-  const daftData = sessionStorage.getItem('transaction-form-data') || '';
-  const hasDraftData = Boolean(daftData);
 
   const onSubmit = (data: TransactionFormDataType) => {
     const isIncome = transactionType === '수입';
-    const isIterationModified = Boolean(dirtyFields.iterationType);
+    const isIterationModified = Boolean(dirtyFields.iterationType) || Boolean(dirtyFields.customIteration);
 
     let body = getFinalData(data, isIncome);
 

--- a/src/pages/AddEditTransactionPage/components/modals/IterationChangeModal.tsx
+++ b/src/pages/AddEditTransactionPage/components/modals/IterationChangeModal.tsx
@@ -43,7 +43,7 @@ const IterationChangeModal = ({ type, onClose }: Props) => {
   const onSubmit = (data: TransactionFormDataType, iterationAction: IterationActionEnumType) => {
     optionRef.current = iterationAction;
     const isIncome = transactionMode === '수입';
-    const isIterationModified = Boolean(dirtyFields.iterationType);
+    const isIterationModified = Boolean(dirtyFields.iterationType) || Boolean(dirtyFields.customIteration);
 
     if (isEditType) {
       const editBody = getFinalData({ ...data, isIterationModified, iterationAction }, isIncome);

--- a/src/pages/AddEditTransactionPage/components/modals/IterationChangeModal.tsx
+++ b/src/pages/AddEditTransactionPage/components/modals/IterationChangeModal.tsx
@@ -4,17 +4,18 @@ import useUpdateTransaction from '@/hooks/apis/transaction/useUpdateTransaction'
 import { IncomeExpenseType, IterationActionEnumType, TransactionFormDataType } from '@/types/transactionTypes';
 import { useFormContext } from 'react-hook-form';
 import useTransactionParams from '@/hooks/transaction/useTransactionParams';
-import { getFinalData } from '@/pages/AddEditTransactionPage/utils/filterTransactionForm';
+import { getFinalData } from '@/utils/form/filterTransactionForm';
 import useDeleteTransaction from '@/hooks/apis/transaction/useDeleteTransaction';
-import useGetUpdateOptions from '../../hooks/useGetUpdateOptions';
 import { useRef } from 'react';
+import { getUpdateOptions } from '@/utils/form/getUpdateOptions';
 
 interface Props {
   type: 'delete' | 'edit';
   onClose: () => void;
+  isIterationModifiedRef?: React.MutableRefObject<boolean>;
 }
 
-const IterationChangeModal = ({ type, onClose }: Props) => {
+const IterationChangeModal = ({ type, onClose, isIterationModifiedRef }: Props) => {
   const {
     handleSubmit,
     setError,
@@ -24,14 +25,12 @@ const IterationChangeModal = ({ type, onClose }: Props) => {
   const isEditType = type === 'edit';
   const isChanged = Object.keys(dirtyFields).length > 0;
 
-  const { content, options } = useGetUpdateOptions({
-    isEditType,
-    dirtyFields: dirtyFields as {
-      iterationType?: boolean;
-      customIteration?: boolean;
-    },
-  });
   const { transactionId, transactionMode } = useTransactionParams();
+  const { content, options } = getUpdateOptions({
+    isEditType,
+    isIterationModified: Boolean(isIterationModifiedRef?.current),
+  });
+
   const { mutate: updateTransaction, isPending: isUpdatePending } = useUpdateTransaction({
     type: transactionMode as IncomeExpenseType,
     setError: setError,
@@ -43,7 +42,7 @@ const IterationChangeModal = ({ type, onClose }: Props) => {
   const onSubmit = (data: TransactionFormDataType, iterationAction: IterationActionEnumType) => {
     optionRef.current = iterationAction;
     const isIncome = transactionMode === '수입';
-    const isIterationModified = Boolean(dirtyFields.iterationType) || Boolean(dirtyFields.customIteration);
+    const isIterationModified = isIterationModifiedRef?.current;
 
     if (isEditType) {
       const editBody = getFinalData({ ...data, isIterationModified, iterationAction }, isIncome);

--- a/src/pages/AddEditTransactionPage/components/modals/custom/selector/IterationEndOptionSelector.tsx
+++ b/src/pages/AddEditTransactionPage/components/modals/custom/selector/IterationEndOptionSelector.tsx
@@ -9,6 +9,7 @@ const IterationEndOptionSelector = () => {
   const { calenderDate } = useCalenderDateStore();
   const { control, register, setValue } = useFormContext<TransactionFormDataType>();
   const end = useWatch({ control, name: 'customIteration.end' });
+  const baseId = useId();
 
   const options = [
     {
@@ -30,6 +31,9 @@ const IterationEndOptionSelector = () => {
                 type="tel"
                 inputMode="numeric"
                 pattern="[0-9]*"
+                min={10}
+                max={999}
+                maxLength={3}
                 placeholder="10"
                 className="w-[40px] text-center  placeholder:text-defaultGrey focus:outline-none"
                 value={field.value}
@@ -77,8 +81,8 @@ const IterationEndOptionSelector = () => {
         <div className="flex flex-col gap-5">
           <span>반복 종료</span>
           <div>
-            {options.map(({ label, value, input }) => {
-              const radioId = useId();
+            {options.map(({ label, value, input }, index) => {
+              const radioId = `${baseId}-${index}`;
               return (
                 <RadioOption
                   key={radioId}

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -7,6 +7,7 @@ import MonthlyContainer from '@/pages/MainPage/components/MonthlyContainer';
 import FetchErrorBoundary from '@/components/error/FetchErrorBoundary';
 import PageErrorBoundary from '@/components/error/PageErrorBoundary';
 import { useCalenderDateStore } from '@/stores/useCalenderDateStore';
+import { format } from 'date-fns';
 
 const MainPage = () => {
   const { mainHeaderDate, setMainHeaderDate } = useHeaderDateStore();
@@ -17,10 +18,10 @@ const MainPage = () => {
       <DateControlHeader headerDate={mainHeaderDate} setHeaderDate={setMainHeaderDate} />
       <div className="flex flex-col grow">
         <PageErrorBoundary>
-          <FetchErrorBoundary key={mainHeaderDate.toISOString()}>
+          <FetchErrorBoundary key={format(mainHeaderDate, 'yyyy-MM')}>
             <MonthlyContainer />
           </FetchErrorBoundary>
-          <FetchErrorBoundary key={calenderDate.toISOString()}>
+          <FetchErrorBoundary key={format(calenderDate, 'yyyy-MM-dd')}>
             <DailyTransactionList />
           </FetchErrorBoundary>
           <PlusCircleButton />

--- a/src/pages/ProfilePage/components/ProfileForm.tsx
+++ b/src/pages/ProfilePage/components/ProfileForm.tsx
@@ -14,7 +14,7 @@ import useDeleteUser from '@/hooks/apis/auth/useDeleteUser';
 import useGetUserDetails from '@/hooks/apis/auth/useGetUserDetails';
 import { useEffect } from 'react';
 import useUpdateUserDetails from '@/hooks/apis/auth/useUpdateUserDetails';
-import { filteredData } from '@/utils/filteredFormData';
+import { filteredData } from '@/utils/form/filteredFormData';
 import LoadingSpinner from '@/components/loading/LoadingSpinner';
 import { useNicknameFieldStore } from '@/stores/fields/useNicknameFieldStore';
 

--- a/src/pages/UpdateEmailPage/UpdateEmailPage.tsx
+++ b/src/pages/UpdateEmailPage/UpdateEmailPage.tsx
@@ -10,7 +10,7 @@ import FetchErrorBoundary from '@/components/error/FetchErrorBoundary';
 const UpdateEmailPage = () => {
   const control = useForm<EmailChangeData>({
     defaultValues: {
-      newEmail: '',
+      email: '',
       verificationCode: 0,
     },
     resolver: zodResolver(emailChangeSchema),

--- a/src/pages/UpdateEmailPage/components/UpdateEmailForm.tsx
+++ b/src/pages/UpdateEmailPage/components/UpdateEmailForm.tsx
@@ -38,7 +38,7 @@ const UpdateEmailForm = () => {
     <form className="flex flex-col justify-between grow px-5 py-8" onSubmit={handleSubmit(onSubmit)}>
       <div className="flex flex-col gap-3">
         <PrimaryInput label="현재 이메일" type="text" readOnly value={userEmail} />
-        <EmailField emailFieldName="newEmail" purpose="changeEmail" />
+        <EmailField emailFieldName="email" purpose="changeEmail" />
       </div>
       <div className="flex justify-end w-full">
         <PrimaryButton label="이메일 변경" disabled={buttonDisabled} type="submit" isPending={isUpdateEmailPending} />

--- a/src/pages/UpdatePasswordPage/components/UpdatePasswordForm.tsx
+++ b/src/pages/UpdatePasswordPage/components/UpdatePasswordForm.tsx
@@ -3,7 +3,7 @@ import PrimaryButton from '@/components/button/PrimaryButton';
 import { Controller, useFormContext } from 'react-hook-form';
 import { ChangePasswordData } from '@/types/authTypes';
 import useUpdatePassword from '@/hooks/apis/auth/useUpdatePassword';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 const UpdatePasswordForm = () => {
   const {
@@ -15,9 +15,14 @@ const UpdatePasswordForm = () => {
     formState: { errors, isValid },
   } = useFormContext<ChangePasswordData>();
   const { mutate: updatePassword, isPending } = useUpdatePassword(setError);
+  const [isVisible, setIsVisible] = useState(false);
 
   const onSubmit = (data: ChangePasswordData) => {
     updatePassword(data);
+  };
+
+  const handleVisibleClick = () => {
+    setIsVisible(prev => !prev);
   };
 
   useEffect(() => {
@@ -48,7 +53,15 @@ const UpdatePasswordForm = () => {
           name="newPassword"
           control={control}
           render={({ field }) => (
-            <PrimaryInput {...field} label="새 비밀번호" type="password" errorMessage={errors.newPassword?.message} />
+            <PrimaryInput
+              {...field}
+              label="새 비밀번호"
+              type={isVisible ? 'text' : 'password'}
+              errorMessage={errors.newPassword?.message}
+              isPassword
+              isPasswordVisible={isVisible}
+              handleVisibleClick={handleVisibleClick}
+            />
           )}
         />
         <Controller

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -69,6 +69,6 @@ export const changePasswordSchema = passwordMatchRefinement(
 );
 
 export const emailChangeSchema = z.object({
-  newEmail: baseSignupSchema.shape.email,
+  email: baseSignupSchema.shape.email,
   verificationCode: baseSignupSchema.shape.verificationCode,
 });

--- a/src/stores/useDraftMetaStore.ts
+++ b/src/stores/useDraftMetaStore.ts
@@ -1,0 +1,9 @@
+import { create } from 'zustand';
+
+export const useDraftMetaStore = create<{
+  hasDraftData: boolean;
+  setHasDraftData: (v: boolean) => void;
+}>(set => ({
+  hasDraftData: false,
+  setHasDraftData: v => set({ hasDraftData: v }),
+}));

--- a/src/types/authTypes.ts
+++ b/src/types/authTypes.ts
@@ -21,8 +21,6 @@ export type GetUserEmailRes = {
   email: string;
 };
 
-export type ChangeEmailReq = Pick<EmailChangeData, 'newEmail'>;
-
 export const emailPurposeList = ['register', 'changeEmail'] as const;
 
 export type EmailPurposeType = (typeof emailPurposeList)[number];

--- a/src/types/authTypes.ts
+++ b/src/types/authTypes.ts
@@ -21,6 +21,10 @@ export type GetUserEmailRes = {
   email: string;
 };
 
+export type ChangeUserEmailReq = {
+  email: string;
+};
+
 export const emailPurposeList = ['register', 'changeEmail'] as const;
 
 export type EmailPurposeType = (typeof emailPurposeList)[number];

--- a/src/utils/form/filterTransactionForm.ts
+++ b/src/utils/form/filterTransactionForm.ts
@@ -1,5 +1,5 @@
 import { TransactionFormDataType } from '@/types/transactionTypes';
-import { filteredData } from '@/utils/filteredFormData';
+import { filteredData } from '@/utils/form/filteredFormData';
 import { omit } from 'lodash';
 
 const getPayload = (data: TransactionFormDataType) => {

--- a/src/utils/form/filteredFormData.ts
+++ b/src/utils/form/filteredFormData.ts
@@ -2,6 +2,6 @@ export const filteredData = <T extends Record<string, unknown>>(data: T): T => {
   return Object.fromEntries(
     Object.entries(data)
       .map(([key, value]) => [key, typeof value === 'string' ? value.trim() : value]) // 값이 문자열이면 trim 처리
-      .filter(([_, value]) => value !== '' && value !== undefined), // trim 처리 후 빈 문자열이나 undefined는 제외
+      .filter(([, value]) => value !== '' && value !== undefined), // trim 처리 후 빈 문자열이나 undefined는 제외
   ) as T;
 };

--- a/src/utils/form/getUpdateOptions.ts
+++ b/src/utils/form/getUpdateOptions.ts
@@ -1,14 +1,9 @@
 interface Props {
   isEditType: boolean;
-  dirtyFields: {
-    iterationType?: boolean;
-    customIteration?: boolean;
-  };
+  isIterationModified: boolean;
 }
 
-const useGetUpdateOptions = ({ isEditType, dirtyFields }: Props) => {
-  const hasChangedIterationFields = dirtyFields.iterationType || dirtyFields.customIteration;
-
+export const getUpdateOptions = ({ isEditType, isIterationModified }: Props) => {
   const content = isEditType ? '해당 가계부를 편집하시겠습니까?' : '해당 가계부를 삭제하시겠습니까?';
 
   const baseOptions = [
@@ -17,7 +12,7 @@ const useGetUpdateOptions = ({ isEditType, dirtyFields }: Props) => {
   ];
 
   const options =
-    hasChangedIterationFields && isEditType
+    isIterationModified && isEditType
       ? baseOptions
       : [{ label: '이 반복 내역에만 적용', value: 'THIS_ONLY' }, ...baseOptions];
 
@@ -26,5 +21,3 @@ const useGetUpdateOptions = ({ isEditType, dirtyFields }: Props) => {
     options,
   };
 };
-
-export default useGetUpdateOptions;

--- a/src/utils/form/hasIterationChanged.ts
+++ b/src/utils/form/hasIterationChanged.ts
@@ -1,0 +1,15 @@
+import { TransactionFormDataType } from '@/types/transactionTypes';
+import { isEqual } from 'lodash';
+
+export const hasIterationChanged = (prev: TransactionFormDataType | undefined, current: TransactionFormDataType) => {
+  const prevType = prev?.iterationType;
+  const currentType = current.iterationType;
+
+  if (prevType !== currentType) return true;
+
+  if (prevType === 'custom' && currentType === 'custom') {
+    return !isEqual(prev?.customIteration, current.customIteration);
+  }
+
+  return false;
+};

--- a/src/utils/invalidateTransactionQueries.ts
+++ b/src/utils/invalidateTransactionQueries.ts
@@ -6,6 +6,10 @@ const invalidateTransactionQueries = (queryClient: QueryClient, date: Date, cate
   const yearMonth = format(date, 'yyyy-MM');
   const yearMonthDay = format(date, 'yyyy-MM-dd');
 
+  queryClient.invalidateQueries({
+    queryKey: ['transaction'],
+  });
+
   // 월별/일별 데이터 조회관련 쿼리키
   queryClient.invalidateQueries({
     queryKey: ['dailyDetails'],

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,7 +1,6 @@
 export const userNameRegex = /^[A-Za-z0-9]+$/;
 
-export const passwordRegex =
-  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+={}[\]:;"'<>,.?/\\|-])[A-Za-z\d!@#$%^&*()_+={}[\]:;"'<>,.?/\\|-]+$/;
+export const passwordRegex = /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[\W_]).+$/;
 
 export const koreanOnlyRegex = /^[가-힣]+$/;
 
@@ -9,4 +8,4 @@ export const nicknameRegex = /^[A-Za-z가-힣ㄱ-ㅎ][A-Za-z가-힣0-9ㄱ-ㅎ]*$
 
 export const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
-export const dayRegex = /^\d{4}\-(0[1-9]|1[0-2])\-(0[1-9]|[12][0-9]|3[01])$/;
+export const dayRegex = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$/;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

### [ 회원 가입 페이지 ] 
- 비밀번호 정규 표현식 수정

### [ 메인 페이지 ]
- 날짜 이동 하면 달력 컴포넌트가 중복 렌더링 되는 에러
  -  `FetchErrorBoundary` 의 key값 중복으로 인해 발생 되는 에러로 추정  

### [ 가계부 작성/편집 페이지 ]

- 사용자화 모달 반복 종료 횟수 input 에 입력 되는 값이 999회 제한
- 임시 데이터 관련 오류 새로고침 or 페이지 이동 하고 돌아왔을 때 저장 버튼이 비활성화 되는 오류
- 반복 데이터 수정 시 사용자화 옵션으로 수정한 경우 isIterationModified 필드 추가 로직 수정
- 반복 데이터 편집 시 날짜 변경 했는데 수정 모달에 2가지 선택지가 뜨는 오류 수정

### [ 카테고리 페이지 ]

- 카테고리 삭제 했을 때 모달창이 제대로 나타나지 않는 오류 수정

### [ 이메일 변경 페이지 ]

- 이메일 인증 에러 발생 시 값을 지워도 에러 초기화가 안되는 오류 수정

## 특이 사항

fetching 했을 때 로딩 화면 나타나는 오류 => ErrorBoundary 로 인해 발생하는 오류로 해당 이슈 새로 파서 진행 예정