### PR TITLE
Feat: Error Loging

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^4.0.0",
+    "@sentry/browser": "^9.32.0",
+    "@sentry/react": "^9.32.0",
+    "@sentry/tracing": "^7.120.3",
     "@tanstack/react-query": "^5.74.3",
     "@tanstack/react-query-devtools": "^5.79.0",
     "axios": "^1.8.4",
@@ -24,7 +27,6 @@
     "react": "^18.3.1",
     "react-datepicker": "^8.2.1",
     "react-dom": "^18.3.1",
-    "react-error-boundary": "^6.0.0",
     "react-hook-form": "^7.54.2",
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@hookform/resolvers':
         specifier: ^4.0.0
         version: 4.0.0(react-hook-form@7.54.2(react@18.3.1))
+      '@sentry/browser':
+        specifier: ^9.32.0
+        version: 9.32.0
+      '@sentry/react':
+        specifier: ^9.32.0
+        version: 9.32.0(react@18.3.1)
+      '@sentry/tracing':
+        specifier: ^7.120.3
+        version: 7.120.3
       '@tanstack/react-query':
         specifier: ^5.74.3
         version: 5.74.3(react@18.3.1)
@@ -44,9 +53,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      react-error-boundary:
-        specifier: ^6.0.0
-        version: 6.0.0(react@18.3.1)
       react-hook-form:
         specifier: ^7.54.2
         version: 7.54.2(react@18.3.1)
@@ -773,6 +779,56 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@sentry-internal/browser-utils@9.32.0':
+    resolution: {integrity: sha512-mVWdruSWXF+2WgS24jwLhWFyC/nDQbKXseLR8paU9LGSnVtlBlQseIx1GrANbJrhBxiEWSft4WiuxU34wPsbXg==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@9.32.0':
+    resolution: {integrity: sha512-OaXaovXqlhN1sG2wtJMhxMEjyeuK7RwY57o96LgKE0bWM//Fs9WWCOkGa+7l8TOf0+0ib7gfhJZlpN0hlqOgRw==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@9.32.0':
+    resolution: {integrity: sha512-tu+coeTRpJxknmWPMJC2jqmIM5IsVoRn9gEDdkSrcPbgx/GwgE03fSJVBJL1tOEA8yRNIhZPMR86ORE7/7n2ow==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@9.32.0':
+    resolution: {integrity: sha512-mOHUKjUtHbEwshikrCQPM1ZqWAMUEcpEGashnXQp3KQivvbTxrExiNnt6XK5TjJyGvsI3A907Bp/HvEzgneYgQ==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/tracing@7.120.3':
+    resolution: {integrity: sha512-Ausx+Jw1pAMbIBHStoQ6ZqDZR60PsCByvHdw/jdH9AqPrNE9xlBSf9EwcycvmrzwyKspSLaB52grlje2cRIUMg==}
+    engines: {node: '>=8'}
+
+  '@sentry/browser@9.32.0':
+    resolution: {integrity: sha512-BzPogpH87n+sC9VPfXaXkiKJtagLpIB87LGg1hSBURpwGx6Rt2ORmaVYgwwuuFZX8Hia727IIM7pbcbNfrXGRQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@7.120.3':
+    resolution: {integrity: sha512-vyy11fCGpkGK3qI5DSXOjgIboBZTriw0YDx/0KyX5CjIjDDNgp5AGgpgFkfZyiYiaU2Ww3iFuKo4wHmBusz1uA==}
+    engines: {node: '>=8'}
+
+  '@sentry/core@9.32.0':
+    resolution: {integrity: sha512-1wAXMMmeY4Ny2MJBCuri3b4LMVPjqXdgbVgTxxipGW+gzPsjv+8+LCSnJAR/cRBr8JoXV+qGC2tE06rI1XDj3A==}
+    engines: {node: '>=18'}
+
+  '@sentry/react@9.32.0':
+    resolution: {integrity: sha512-4d13sA/e9oEEK9cB6DZxVNDLTw9Q2x0WzhKtit6jhFKv1ItQ61Uu+euBJLfy3yCzFGl7PJbfJViMt2bhqjkTuA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/tracing@7.120.3':
+    resolution: {integrity: sha512-B7bqyYFgHuab1Pn7w5KXsZP/nfFo4VDBDdSXDSWYk5+TYJ3IDruO3eJFhOrircfsz4YwazWm9kbeZhkpsHDyHg==}
+    engines: {node: '>=8'}
+
+  '@sentry/types@7.120.3':
+    resolution: {integrity: sha512-C4z+3kGWNFJ303FC+FxAd4KkHvxpNFYAFN8iMIgBwJdpIl25KZ8Q/VdGn0MLLUEHNLvjob0+wvwlcRBBNLXOow==}
+    engines: {node: '>=8'}
+
+  '@sentry/utils@7.120.3':
+    resolution: {integrity: sha512-UDAOQJtJDxZHQ5Nm1olycBIsz2wdGX8SdzyGVHmD8EOQYAeDZQyIlQYohDe9nazdIOQLZCIc3fU0G9gqVLkaGQ==}
+    engines: {node: '>=8'}
 
   '@storybook/addon-actions@8.5.3':
     resolution: {integrity: sha512-7a+SD4EZdZocm+NG1Kx4yV6Aw7+YUlRIyGvKcxsGtYMOLaqrUewApqveXF83+FbYWMoezXcoZCLQFROtS/Z6Fw==}
@@ -2128,6 +2184,9 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -2734,11 +2793,6 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
-
-  react-error-boundary@6.0.0:
-    resolution: {integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==}
-    peerDependencies:
-      react: '>=16.13.1'
 
   react-hook-form@7.54.2:
     resolution: {integrity: sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==}
@@ -3905,6 +3959,62 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@sentry-internal/browser-utils@9.32.0':
+    dependencies:
+      '@sentry/core': 9.32.0
+
+  '@sentry-internal/feedback@9.32.0':
+    dependencies:
+      '@sentry/core': 9.32.0
+
+  '@sentry-internal/replay-canvas@9.32.0':
+    dependencies:
+      '@sentry-internal/replay': 9.32.0
+      '@sentry/core': 9.32.0
+
+  '@sentry-internal/replay@9.32.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 9.32.0
+      '@sentry/core': 9.32.0
+
+  '@sentry-internal/tracing@7.120.3':
+    dependencies:
+      '@sentry/core': 7.120.3
+      '@sentry/types': 7.120.3
+      '@sentry/utils': 7.120.3
+
+  '@sentry/browser@9.32.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 9.32.0
+      '@sentry-internal/feedback': 9.32.0
+      '@sentry-internal/replay': 9.32.0
+      '@sentry-internal/replay-canvas': 9.32.0
+      '@sentry/core': 9.32.0
+
+  '@sentry/core@7.120.3':
+    dependencies:
+      '@sentry/types': 7.120.3
+      '@sentry/utils': 7.120.3
+
+  '@sentry/core@9.32.0': {}
+
+  '@sentry/react@9.32.0(react@18.3.1)':
+    dependencies:
+      '@sentry/browser': 9.32.0
+      '@sentry/core': 9.32.0
+      hoist-non-react-statics: 3.3.2
+      react: 18.3.1
+
+  '@sentry/tracing@7.120.3':
+    dependencies:
+      '@sentry-internal/tracing': 7.120.3
+
+  '@sentry/types@7.120.3': {}
+
+  '@sentry/utils@7.120.3':
+    dependencies:
+      '@sentry/types': 7.120.3
 
   '@storybook/addon-actions@8.5.3(storybook@8.5.3(prettier@3.5.0))':
     dependencies:
@@ -5444,6 +5554,10 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -6044,11 +6158,6 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
-
-  react-error-boundary@6.0.0(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.26.7
-      react: 18.3.1
 
   react-hook-form@7.54.2(react@18.3.1):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import ChartPage from '@/pages/ChartPage/ChartPage';
 import CategoryDetailsPage from '@/pages/CategoryDetailsPage/CategoryDetailsPage';
 import ProtectedRoute from '@/components/route/ProtectedRoute';
 import RedirectIfLoggedInRoute from '@/components/route/RedirectIfLoggedInRoute';
+import ErrorPage from '@/pages/ErrorPage/ErrorPage';
 
 function App() {
   return (
@@ -40,6 +41,7 @@ function App() {
         <Route path="/chart" element={<ChartPage />} />
         <Route path="/chart/category-details/:categoryId" element={<CategoryDetailsPage />} />
       </Route>
+      <Route path="*" element={<ErrorPage />} />
     </Routes>
   );
 }

--- a/src/api/services/chartService.ts
+++ b/src/api/services/chartService.ts
@@ -30,6 +30,7 @@ export const getExpenseStackedBarChart = async (date: string) => {
     'GET',
     endpoints.chart.getExpenseStackedBarChart(date),
   );
+  if (!res.data) throw new Error('No Data');
   return res.data;
 };
 
@@ -38,16 +39,19 @@ export const getIncomeStackedBarChart = async (date: string) => {
     'GET',
     endpoints.chart.getIncomeStackedBarChart(date),
   );
+  if (!res.data) throw new Error('No Data');
   return res.data;
 };
 
 export const getExpenseBarChart = async (date: string) => {
   const res = await fetchData<undefined, BarChartResponse>('GET', endpoints.chart.getExpenseBarChart(date));
+  if (!res.data) throw new Error('No Data');
   return res.data;
 };
 
 export const getIncomeBarChart = async (date: string) => {
   const res = await fetchData<undefined, BarChartResponse>('GET', endpoints.chart.getIncomeBarChart(date));
+  if (!res.data) throw new Error('No Data');
   return res.data;
 };
 
@@ -56,6 +60,7 @@ export const getCategoryDetailsLineChart = async (categoryId: string, date: stri
     'GET',
     endpoints.chart.getLineChart(categoryId, date),
   );
+  if (!res.data) throw new Error('No Data');
   return res.data;
 };
 
@@ -64,6 +69,7 @@ export const getCategoryDetailsBarChart = async (categoryId: string, date: strin
     'GET',
     endpoints.chart.getVerticalBarChart(categoryId, date),
   );
+  if (!res.data) throw new Error('No Data');
   return res.data;
 };
 

--- a/src/api/services/reportService.ts
+++ b/src/api/services/reportService.ts
@@ -4,6 +4,7 @@ import { AnnualFinanceReportType, WeeklyDetailsSummaryType, WeeklySummaryType } 
 
 export const getYearlySummary = async (date: string) => {
   const res = await fetchData<undefined, AnnualFinanceReportType>('GET', endpoints.report.getYearlySummary(date));
+  if (!res.data) throw new Error('No data');
   return res.data;
 };
 

--- a/src/components/error/FetchErrorBoundary.tsx
+++ b/src/components/error/FetchErrorBoundary.tsx
@@ -1,12 +1,21 @@
-import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+import * as Sentry from '@sentry/react';
 import { handleFetchError } from '@/utils/error/handleFetchError';
+import { SentryFallbackProps } from '@/types/types';
 
-export const FetchFallback = ({ error }: FallbackProps) => {
+export const FetchFallback = ({ error }: SentryFallbackProps) => {
   return handleFetchError(error);
 };
 
 const FetchErrorBoundary = ({ children }: { children: React.ReactNode }) => {
-  return <ErrorBoundary FallbackComponent={FetchFallback}>{children}</ErrorBoundary>;
+  return (
+    <Sentry.ErrorBoundary
+      onError={error => {
+        Sentry.captureException(error);
+      }}
+      fallback={(props: SentryFallbackProps) => <FetchFallback {...props} />}>
+      {children}
+    </Sentry.ErrorBoundary>
+  );
 };
 
 export default FetchErrorBoundary;

--- a/src/components/error/FetchErrorBoundary.tsx
+++ b/src/components/error/FetchErrorBoundary.tsx
@@ -1,18 +1,8 @@
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
-import { isFetchError } from '@/utils/error/isFetchError';
-import { getFetchFallbackByStatus } from '@/components/error/getFetchFallbackByStatus';
+import { handleFetchError } from '@/utils/error/handleFetchError';
 
-const FetchFallback = ({ error }: FallbackProps) => {
-  if (isFetchError(error)) {
-    return (
-      <div className="w-full grow flex flex-col justify-center items-center gap-3.5 p-5">
-        {getFetchFallbackByStatus(error)}
-      </div>
-    );
-  }
-
-  // PageErrorBoundary로 throw
-  throw error;
+export const FetchFallback = ({ error }: FallbackProps) => {
+  return handleFetchError(error);
 };
 
 const FetchErrorBoundary = ({ children }: { children: React.ReactNode }) => {

--- a/src/components/error/GlobalErrorBoundary.tsx
+++ b/src/components/error/GlobalErrorBoundary.tsx
@@ -1,21 +1,33 @@
-import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+import * as Sentry from '@sentry/react';
 import PrimaryButton from '@/components/button/PrimaryButton';
+import { SentryFallbackProps } from '@/types/types';
 import { BiShocked } from 'react-icons/bi';
 
-const GlobalFallback = ({ error }: FallbackProps) => {
+const GlobalFallback = ({ error }: SentryFallbackProps) => {
+  const message = error instanceof Error ? `Error: ${error.message}` : '잠시후에 다시 시도해주십시오.';
+
   return (
     <div className="w-full min-h-screen flex flex-col justify-center items-center gap-5">
       <BiShocked size={75} color="gray" />
       <h2 className="text-xl font-bold">예기치 못한 문제가 발생했습니다.</h2>
       <p>서비스 이용에 불편을 드려 죄송합니다.</p>
-      <p className="text-defaultGrey">{error.message ? `Error: ${error.message}` : '잠시후에 다시 시도해주십시오.'}</p>
+      <p className="text-defaultGrey">{message}</p>
       <PrimaryButton label="새로고침" onClick={() => window.location.reload()} color={'bg-lightBlue text-oceanBlue'} />
     </div>
   );
 };
 
 const GlobalErrorBoundary = ({ children }: { children: React.ReactNode }) => {
-  return <ErrorBoundary FallbackComponent={GlobalFallback}>{children}</ErrorBoundary>;
+  return (
+    <Sentry.ErrorBoundary
+      onError={error => {
+        Sentry.captureException(error);
+      }}
+      fallback={(props: SentryFallbackProps) => <GlobalFallback {...props} />}
+      showDialog={false}>
+      {children}
+    </Sentry.ErrorBoundary>
+  );
 };
 
 export default GlobalErrorBoundary;

--- a/src/components/error/GlobalErrorBoundary.tsx
+++ b/src/components/error/GlobalErrorBoundary.tsx
@@ -5,7 +5,7 @@ import { BiShocked } from 'react-icons/bi';
 const GlobalFallback = ({ error }: FallbackProps) => {
   return (
     <div className="w-full min-h-screen flex flex-col justify-center items-center gap-5">
-      <BiShocked size={80} color="red" />
+      <BiShocked size={75} color="gray" />
       <h2 className="text-xl font-bold">예기치 못한 문제가 발생했습니다.</h2>
       <p>서비스 이용에 불편을 드려 죄송합니다.</p>
       <p className="text-defaultGrey">{error.message ? `Error: ${error.message}` : '잠시후에 다시 시도해주십시오.'}</p>

--- a/src/components/error/PageErrorBoundary.tsx
+++ b/src/components/error/PageErrorBoundary.tsx
@@ -1,11 +1,12 @@
-import { ErrorBoundary } from 'react-error-boundary';
-import { FallbackProps } from 'react-error-boundary';
+import * as Sentry from '@sentry/react';
 import ServerErrorFallback from './fallbacks/ServerErrorFallback';
 import PrimaryButton from '@/components/button/PrimaryButton';
 import { LuFileWarning } from 'react-icons/lu';
+import { SentryFallbackProps } from '@/types/types';
+import CustomError from '@/utils/error/CustomError';
 
-const PageFallback = ({ error }: FallbackProps) => {
-  if (error.statusCode >= 500) {
+const PageFallback = ({ error }: SentryFallbackProps) => {
+  if (error instanceof CustomError && error.statusCode >= 500) {
     return <ServerErrorFallback />;
   }
 
@@ -25,7 +26,15 @@ const PageFallback = ({ error }: FallbackProps) => {
 };
 
 const PageErrorBoundary = ({ children }: { children: React.ReactNode }) => {
-  return <ErrorBoundary FallbackComponent={PageFallback}>{children}</ErrorBoundary>;
+  return (
+    <Sentry.ErrorBoundary
+      onError={error => {
+        Sentry.captureException(error);
+      }}
+      fallback={(props: SentryFallbackProps) => <PageFallback {...props} />}>
+      {children}
+    </Sentry.ErrorBoundary>
+  );
 };
 
 export default PageErrorBoundary;

--- a/src/components/error/PageErrorBoundary.tsx
+++ b/src/components/error/PageErrorBoundary.tsx
@@ -10,8 +10,8 @@ const PageFallback = ({ error }: FallbackProps) => {
   }
 
   return (
-    <div className="w-full grow flex flex-col justify-center items-center gap-5">
-      <LuFileWarning size={80} color={'red'} />
+    <div className="w-full grow flex flex-col justify-center items-center gap-7">
+      <LuFileWarning size={70} color={'gray'} />
       <h1 className="text-xl font-bold">페이지를 불러오는 데 문제가 발생했습니다.</h1>
       <p>다시 시도하거나 홈으로 돌아가주세요.</p>
       <PrimaryButton label="새로고침" onClick={() => window.location.reload()} color={'bg-lightBlue text-oceanBlue'} />

--- a/src/components/error/fallbacks/NotFoundFallback.tsx
+++ b/src/components/error/fallbacks/NotFoundFallback.tsx
@@ -2,7 +2,7 @@ const NotFoundFallback = () => {
   return (
     <div className="w-full flex flex-col justify-center items-center gap-5">
       <h2 className="text-lg font-bold">404 NotFound</h2>
-      <p className="text-defaultGrey">데이터를 찾을 수 없습니다.</p>
+      <p className="text-defaultGrey">요청하신 리소스를 찾을 수 없습니다.</p>
     </div>
   );
 };

--- a/src/hooks/apis/auth/useSignup.ts
+++ b/src/hooks/apis/auth/useSignup.ts
@@ -5,6 +5,7 @@ import { useMutation } from '@tanstack/react-query';
 import { UseFormSetError } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 
 interface Props {
   setError: UseFormSetError<SignupFormType>;
@@ -33,6 +34,8 @@ const useSignup = ({ setError, fieldStatusMap }: Props) => {
 
         resetFieldStatus?.();
       } else toast.error(error.message);
+
+      Sentry.captureException(error);
     },
   });
 };

--- a/src/hooks/apis/category/useAddCategory.ts
+++ b/src/hooks/apis/category/useAddCategory.ts
@@ -1,7 +1,7 @@
 import { addExpenseCategory, addIncomeCategory } from '@/api/services/categoryService';
 import { BaseCategoriesType } from '@/types/categoryTypes';
 import { IncomeExpenseType } from '@/types/transactionTypes';
-import CustomError from '@/utils/error/CustomError';
+import { createFormErrorHandler } from '@/utils/error/errorHandler';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { UseFormSetError } from 'react-hook-form';
 import toast from 'react-hot-toast';
@@ -29,12 +29,7 @@ const useAddCategory = ({ type, setError }: Props) => {
       toast.success(data.message);
       navigate(-1);
     },
-    onError: (error: CustomError) => {
-      setError('name', {
-        type: 'server',
-        message: `${error.message}`,
-      });
-    },
+    onError: createFormErrorHandler(setError),
   });
 };
 

--- a/src/hooks/apis/category/useUpdateCategoryVisibility.ts
+++ b/src/hooks/apis/category/useUpdateCategoryVisibility.ts
@@ -3,6 +3,7 @@ import { updateCategoryVisibility } from '@/api/services/categoryService';
 import { CategoryVisibility, DefaultCategoriesType } from '@/types/categoryTypes';
 import toast from 'react-hot-toast';
 import { IncomeExpenseType } from '@/types/transactionTypes';
+import * as Sentry from '@sentry/react';
 
 interface Props {
   type: IncomeExpenseType;
@@ -37,6 +38,7 @@ const useUpdateCategoryVisibility = ({ type }: Props) => {
         queryClient.setQueryData(['defaultCategories', type], context.previousData);
       }
       toast.error(error.message);
+      Sentry.captureException(error);
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['defaultCategories', type] });

--- a/src/hooks/apis/chart/useGetBarChart.ts
+++ b/src/hooks/apis/chart/useGetBarChart.ts
@@ -9,6 +9,7 @@ const useGetBarChart = (transactionType: IncomeExpenseType, date: string) => {
     queryKey: ['barChart', date, transactionType],
     queryFn: () => queryFn(date),
     placeholderData: keepPreviousData,
+    throwOnError: false,
     staleTime: 10 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
   });

--- a/src/hooks/apis/chart/useGetStackedBarChart.ts
+++ b/src/hooks/apis/chart/useGetStackedBarChart.ts
@@ -9,6 +9,7 @@ const useGetStackedBarChart = (transactionType: IncomeExpenseType, date: string)
     queryKey: ['stackedBarChart', date, transactionType],
     queryFn: () => queryFn(date),
     placeholderData: keepPreviousData,
+    throwOnError: false,
     staleTime: 10 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
   });

--- a/src/hooks/apis/chart/useGetTotalAndSavings.ts
+++ b/src/hooks/apis/chart/useGetTotalAndSavings.ts
@@ -9,6 +9,7 @@ const useGetTotalAndSavings = (transactionType: IncomeExpenseType, date: string)
     queryKey: ['totalAndSavings', date, transactionType],
     queryFn: () => queryFn(date),
     placeholderData: keepPreviousData,
+    throwOnError: false,
     staleTime: 10 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
   });

--- a/src/hooks/apis/report/useGetYearlySummary.ts
+++ b/src/hooks/apis/report/useGetYearlySummary.ts
@@ -6,6 +6,7 @@ const useGetYearlySummary = (date: string) => {
     queryKey: ['yearlySummary', date],
     queryFn: () => getYearlySummary(date),
     placeholderData: keepPreviousData,
+    throwOnError: false,
     staleTime: 10 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
   });

--- a/src/hooks/apis/transaction/useGetDailyDetails.ts
+++ b/src/hooks/apis/transaction/useGetDailyDetails.ts
@@ -5,6 +5,7 @@ const useGetDailyDetails = (date: string) => {
   return useQuery({
     queryKey: ['dailyDetails', date],
     queryFn: () => getDailyDetails(date),
+    throwOnError: false,
     placeholderData: keepPreviousData,
     staleTime: 10 * 60 * 1000,
     gcTime: 15 * 60 * 1000,

--- a/src/hooks/apis/transaction/useGetMonthlyTotal.ts
+++ b/src/hooks/apis/transaction/useGetMonthlyTotal.ts
@@ -7,6 +7,7 @@ const useGetMonthlyTotal = (date: string) => {
     queryKey: ['monthlyTotal', date],
     queryFn: () => getMonthlyTotal(date),
     placeholderData: keepPreviousData,
+    throwOnError: false,
     staleTime: 10 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
   });

--- a/src/libs/queryClient.ts
+++ b/src/libs/queryClient.ts
@@ -1,6 +1,7 @@
 import { QueryClient } from '@tanstack/react-query';
 import CustomError from '@/utils/error/CustomError';
 import { toast } from 'react-hot-toast';
+import * as Sentry from '@sentry/react';
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -21,6 +22,8 @@ export const queryClient = new QueryClient({
         } else {
           toast.error('알 수 없는 오류가 발생했습니다.\n 잠시 후 다시 시도해주세요.');
         }
+
+        Sentry.captureException(error);
       },
     },
   },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { queryClient } from '@/libs/queryClient.ts';
 import GlobalErrorBoundary from '@/components/error/GlobalErrorBoundary.tsx';
+import './sentry';
 
 if (typeof window !== 'undefined') {
   if (import.meta.env.DEV) {

--- a/src/pages/ChartPage/ChartPage.tsx
+++ b/src/pages/ChartPage/ChartPage.tsx
@@ -7,15 +7,10 @@ import ReportTypeSelection from '@/pages/ChartPage/components/ReportTypeSelectio
 import ReportSummary from '@/pages/ChartPage/components/summary/ReportSummary';
 import { useHeaderDateStore } from '@/stores/useHeaderDateStore';
 import CategoryChartBoard from '@/pages/ChartPage/components/categories/CategoryChartBoard';
-import FetchErrorBoundary from '@/components/error/FetchErrorBoundary';
-import { useTransactionReportTypeStore } from '@/stores/chart/useTransactionReportTypeStore';
-import useFormattedReportDate from '@/hooks/chart/useFormattedReportDate';
 import PageErrorBoundary from '@/components/error/PageErrorBoundary';
 
 const ChartPage = () => {
   const { chartHeaderDate, setChartHeaderDate } = useHeaderDateStore();
-  const formattedDate = useFormattedReportDate();
-  const { currentTransactionType } = useTransactionReportTypeStore();
 
   return (
     <div className="flex flex-col w-full min-h-screen">
@@ -26,16 +21,10 @@ const ChartPage = () => {
             <ReportTypeSelection />
             <TransactionTypeButton />
           </div>
-          <FetchErrorBoundary key={`${currentTransactionType}-${formattedDate}-summary`}>
-            <ReportSummary />
-          </FetchErrorBoundary>
-          <FetchErrorBoundary key={`${currentTransactionType}-${formattedDate}-chartBoard`}>
-            <CategoryChartBoard />
-          </FetchErrorBoundary>
+          <ReportSummary />
+          <CategoryChartBoard />
           <Divider />
-          <FetchErrorBoundary key={`${currentTransactionType}-${formattedDate}-period`}>
-            <PeriodComparisonChart />
-          </FetchErrorBoundary>
+          <PeriodComparisonChart />
         </PageErrorBoundary>
       </div>
       <TapBar page="chart" />

--- a/src/pages/ChartPage/components/categories/CategoryChartBoard.tsx
+++ b/src/pages/ChartPage/components/categories/CategoryChartBoard.tsx
@@ -4,14 +4,20 @@ import { useTransactionReportTypeStore } from '@/stores/chart/useTransactionRepo
 import StackedBarChart from '@/pages/ChartPage/components/categories/StackedBarChart';
 import CategoryDashBoard from '@/pages/ChartPage/components/categories/CategoryDashBoard';
 import Skeleton from '@/components/loading/Skeleton';
+import { handleFetchError } from '@/utils/error/handleFetchError';
 
 const CategoryChartBoard = () => {
   const { currentTransactionType } = useTransactionReportTypeStore();
   const formattedDate = useFormattedReportDate();
 
-  const { data: stackedBarChartData, isPending } = useGetStackedBarChart(currentTransactionType, formattedDate);
+  const {
+    data: stackedBarChartData,
+    isPending,
+    isError,
+    error,
+  } = useGetStackedBarChart(currentTransactionType, formattedDate);
 
-  if (!stackedBarChartData || isPending) {
+  if (isPending) {
     return (
       <>
         <div className="p-5">
@@ -23,6 +29,10 @@ const CategoryChartBoard = () => {
         </div>
       </>
     );
+  }
+
+  if (isError && error) {
+    return handleFetchError(error);
   }
 
   return (

--- a/src/pages/ChartPage/components/period/PeriodComparisonChart.tsx
+++ b/src/pages/ChartPage/components/period/PeriodComparisonChart.tsx
@@ -8,6 +8,7 @@ import useFormattedReportDate from '@/hooks/chart/useFormattedReportDate';
 import Skeleton from '@/components/loading/Skeleton';
 import CustomXAxisTick from '@/pages/ChartPage/components/period/CustomXAxisTick';
 import PeriodComparisonCustomLabel from '@/pages/ChartPage/components/period/PeriodComparisonCustomLabel';
+import { handleFetchError } from '@/utils/error/handleFetchError';
 
 const PeriodComparisonChart = () => {
   const formattedDate = useFormattedReportDate();
@@ -15,13 +16,13 @@ const PeriodComparisonChart = () => {
   const { currentTransactionType } = useTransactionReportTypeStore();
   const { currentReportType } = useReportTypeStore();
 
-  const { data: barChartData, isPending } = useGetBarChart(currentTransactionType, formattedDate);
+  const { data: barChartData, isPending, isError, error } = useGetBarChart(currentTransactionType, formattedDate);
 
   const handleBarCharClick = (date: string) => {
     setChartHeaderDate(new Date(date));
   };
 
-  if (!barChartData || isPending) {
+  if (isPending) {
     return (
       <div className="flex flex-col grow p-5 gap-30">
         <div className="flex flex-col gap-3">
@@ -35,6 +36,10 @@ const PeriodComparisonChart = () => {
         </div>
       </div>
     );
+  }
+
+  if (isError && error) {
+    return handleFetchError(error);
   }
 
   return (

--- a/src/pages/ChartPage/components/summary/ReportSummary.tsx
+++ b/src/pages/ChartPage/components/summary/ReportSummary.tsx
@@ -5,15 +5,25 @@ import { useTransactionReportTypeStore } from '@/stores/chart/useTransactionRepo
 import { handleClickCategoryChart } from '@/pages/ChartPage/utils/handleClickCategoryChart';
 import { useNavigate } from 'react-router-dom';
 import { useReportTypeStore } from '@/stores/chart/useReportTypeStore';
+import { handleFetchError } from '@/utils/error/handleFetchError';
 
 const ReportSummary = () => {
   const navigate = useNavigate();
   const { currentReportType } = useReportTypeStore();
   const { currentTransactionType } = useTransactionReportTypeStore();
   const formattedDate = useFormattedReportDate();
-  const { data: totalAndSavings, isPending } = useGetTotalAndSavings(currentTransactionType, formattedDate);
+  const {
+    data: totalAndSavings,
+    isPending,
+    isError,
+    error,
+  } = useGetTotalAndSavings(currentTransactionType, formattedDate);
 
   const categoryName = '저축/투자';
+
+  if (isError && error) {
+    return handleFetchError(error);
+  }
 
   return (
     <div className="w-full flex justify-between px-8 py-4 gap-3.5">

--- a/src/pages/ErrorPage/ErrorPage.tsx
+++ b/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,0 +1,22 @@
+import PrimaryButton from '@/components/button/PrimaryButton';
+import NotFoundFallback from '@/components/error/fallbacks/NotFoundFallback';
+import { PiNoteLight } from 'react-icons/pi';
+import { useNavigate } from 'react-router-dom';
+
+const ErrorPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="w-full min-h-screen flex flex-col items-center justify-center gap-10">
+      <PiNoteLight size={70} color="gray" />
+      <NotFoundFallback />
+      <PrimaryButton
+        label="홈으로"
+        color={'bg-lightBlue text-oceanBlue'}
+        onClick={() => navigate('/', { replace: true })}
+      />
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -4,26 +4,18 @@ import TapBar from '@/components/tapbar/TapBar';
 import DailyTransactionList from '@/pages/MainPage/components/daily/DailyTransactionList';
 import { useHeaderDateStore } from '@/stores/useHeaderDateStore';
 import MonthlyContainer from '@/pages/MainPage/components/MonthlyContainer';
-import FetchErrorBoundary from '@/components/error/FetchErrorBoundary';
 import PageErrorBoundary from '@/components/error/PageErrorBoundary';
-import { useCalenderDateStore } from '@/stores/useCalenderDateStore';
-import { format } from 'date-fns';
 
 const MainPage = () => {
   const { mainHeaderDate, setMainHeaderDate } = useHeaderDateStore();
-  const { calenderDate } = useCalenderDateStore();
 
   return (
     <div className="w-full min-h-screen flex flex-col relative">
       <DateControlHeader headerDate={mainHeaderDate} setHeaderDate={setMainHeaderDate} />
       <div className="flex flex-col grow">
         <PageErrorBoundary>
-          <FetchErrorBoundary key={format(mainHeaderDate, 'yyyy-MM')}>
-            <MonthlyContainer />
-          </FetchErrorBoundary>
-          <FetchErrorBoundary key={format(calenderDate, 'yyyy-MM-dd')}>
-            <DailyTransactionList />
-          </FetchErrorBoundary>
+          <MonthlyContainer />
+          <DailyTransactionList />
           <PlusCircleButton />
         </PageErrorBoundary>
       </div>

--- a/src/pages/MainPage/components/MonthlyContainer.tsx
+++ b/src/pages/MainPage/components/MonthlyContainer.tsx
@@ -3,19 +3,24 @@ import TransactionSummary from '@/components/summary/TransactionSummary';
 import useGetMonthlyTotal from '@/hooks/apis/transaction/useGetMonthlyTotal';
 import Calender from '@/pages/MainPage/components/calender/Calender';
 import { useHeaderDateStore } from '@/stores/useHeaderDateStore';
+import { handleFetchError } from '@/utils/error/handleFetchError';
 import { format } from 'date-fns';
 
 const MonthlyContainer = () => {
   const { mainHeaderDate } = useHeaderDateStore();
-  const { data: monthlyTotal, isPending } = useGetMonthlyTotal(format(mainHeaderDate, 'yyyy-MM'));
+  const { data: monthlyTotal, isPending, isError, error } = useGetMonthlyTotal(format(mainHeaderDate, 'yyyy-MM'));
 
-  if (!monthlyTotal || isPending) {
+  if (isPending) {
     return (
       <div className="flex flex-col gap-2.5 p-5">
         <Skeleton height="h-32" />
         <Skeleton height="h-[38rem]" />
       </div>
     );
+  }
+
+  if (isError && error) {
+    return handleFetchError(error);
   }
 
   return (

--- a/src/pages/MainPage/components/daily/DailyTransactionList.tsx
+++ b/src/pages/MainPage/components/daily/DailyTransactionList.tsx
@@ -7,10 +7,11 @@ import DailySummeryItem from '@/pages/MainPage/components/daily/DailySummeryItem
 import Skeleton from '@/components/loading/Skeleton';
 import { ko } from 'date-fns/locale';
 import useScrollToSelectedRef from '@/hooks/useScrollToSelectedRef';
+import { handleFetchError } from '@/utils/error/handleFetchError';
 
 const DailyTransactionList = () => {
   const { calenderDate } = useCalenderDateStore();
-  const { data: dailyDetails, isPending } = useGetDailyDetails(format(calenderDate, 'yyyy-MM-dd'));
+  const { data: dailyDetails, isPending, isError, error } = useGetDailyDetails(format(calenderDate, 'yyyy-MM-dd'));
   const isEmpty = dailyDetails?.dailyDetails.length === 0;
   const { selectedRef, targetItem } = useScrollToSelectedRef('id', dailyDetails?.dailyDetails);
 
@@ -29,6 +30,10 @@ const DailyTransactionList = () => {
         </div>
       </div>
     );
+  }
+
+  if (isError && error) {
+    return handleFetchError(error);
   }
 
   return (

--- a/src/pages/MonthWeekPage/MonthWeekPage.tsx
+++ b/src/pages/MonthWeekPage/MonthWeekPage.tsx
@@ -2,7 +2,6 @@ import DateControlHeader from '@/components/header/DateControlHeader';
 import TapBar from '@/components/tapbar/TapBar';
 import { useHeaderDateStore } from '@/stores/useHeaderDateStore';
 import YearlySummarySection from '@/pages/MonthWeekPage/components/YearlySummarySection';
-import FetchErrorBoundary from '@/components/error/FetchErrorBoundary';
 import PageErrorBoundary from '@/components/error/PageErrorBoundary';
 
 const MonthWeekPage = () => {
@@ -12,9 +11,7 @@ const MonthWeekPage = () => {
     <div className="w-full h-fit min-h-screen max-h-fit flex flex-col relative">
       <DateControlHeader headerDate={monthWeekHeaderDate} setHeaderDate={setMonthWeekHeaderDate} />
       <PageErrorBoundary>
-        <FetchErrorBoundary key={monthWeekHeaderDate.toISOString()}>
-          <YearlySummarySection />
-        </FetchErrorBoundary>
+        <YearlySummarySection />
       </PageErrorBoundary>
       <TapBar page="month-week" />
     </div>

--- a/src/pages/MonthWeekPage/components/YearlySummarySection.tsx
+++ b/src/pages/MonthWeekPage/components/YearlySummarySection.tsx
@@ -4,18 +4,23 @@ import useGetYearlySummary from '@/hooks/apis/report/useGetYearlySummary';
 import { useHeaderDateStore } from '@/stores/useHeaderDateStore';
 import { format } from 'date-fns';
 import LoadingSpinner from '@/components/loading/LoadingSpinner';
+import { handleFetchError } from '@/utils/error/handleFetchError';
 
 const YearlySummarySection = () => {
   const { monthWeekHeaderDate } = useHeaderDateStore();
   const targetYear = format(monthWeekHeaderDate, 'yyyy');
-  const { data: yearlySummaryData, isPending } = useGetYearlySummary(targetYear);
+  const { data: yearlySummaryData, isPending, isError, error } = useGetYearlySummary(targetYear);
 
-  if (isPending || !yearlySummaryData) {
+  if (isPending) {
     return (
       <div className="flex flex-col grow justify-center items-center">
         <LoadingSpinner size={30} />
       </div>
     );
+  }
+
+  if (isError && error) {
+    return handleFetchError(error);
   }
 
   return (

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/react';
 
 Sentry.init({
-  dsn: import.meta.env.VITE_SENTRY_DSN,
+  dsn: import.meta.env.DEV ? undefined : import.meta.env.VITE_SENTRY_DSN,
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 0.3,
   environment: import.meta.env.MODE,

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/react';
+
+Sentry.init({
+  dsn: import.meta.env.VITE_SENTRY_DSN,
+  integrations: [Sentry.browserTracingIntegration()],
+  tracesSampleRate: 0.3,
+  environment: import.meta.env.MODE,
+});

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -8,3 +8,10 @@ export type SettingOptionType = {
 export type TapBarType = 'main' | 'month-week' | 'chart' | 'talk' | 'setting';
 
 export type ModalType = 'logout' | 'dataReset' | null;
+
+export interface SentryFallbackProps {
+  error: unknown;
+  componentStack?: string;
+  eventId?: string;
+  resetError?: () => void;
+}

--- a/src/utils/error/errorHandler.ts
+++ b/src/utils/error/errorHandler.ts
@@ -1,6 +1,7 @@
 import { FieldValues, Path, UseFormSetError } from 'react-hook-form';
 import CustomError from '@/utils/error/CustomError';
 import toast from 'react-hot-toast';
+import * as Sentry from '@sentry/react';
 
 // 폼 데이터의 상태 변경이 필요한 Error 처리 핸들러
 export const createFormErrorHandler = <T extends FieldValues, E = unknown>(
@@ -29,6 +30,8 @@ export const createFormErrorHandler = <T extends FieldValues, E = unknown>(
     } else {
       toast.error('알 수 없는 오류가 발생했습니다.\n 잠시 후 다시 시도해주세요.');
     }
+
+    Sentry.captureException(error);
   };
 };
 
@@ -43,4 +46,6 @@ export const handleCustomError = (error: unknown, fallback?: (error: CustomError
   } else {
     toast.error('알 수 없는 오류가 발생했습니다.\n 잠시 후 다시 시도해주세요.');
   }
+
+  Sentry.captureException(error);
 };

--- a/src/utils/error/handleFetchError.tsx
+++ b/src/utils/error/handleFetchError.tsx
@@ -1,0 +1,14 @@
+import { getFetchFallbackByStatus } from '@/components/error/getFetchFallbackByStatus';
+import { isFetchError } from '@/utils/error/isFetchError';
+
+export const handleFetchError = (error: unknown) => {
+  if (isFetchError(error)) {
+    return (
+      <div className="w-full grow flex flex-col justify-center items-center gap-3.5 p-5">
+        {getFetchFallbackByStatus(error)}
+      </div>
+    );
+  }
+
+  throw error;
+};

--- a/src/utils/error/handleFetchError.tsx
+++ b/src/utils/error/handleFetchError.tsx
@@ -1,8 +1,11 @@
 import { getFetchFallbackByStatus } from '@/components/error/getFetchFallbackByStatus';
 import { isFetchError } from '@/utils/error/isFetchError';
+import * as Sentry from '@sentry/react';
 
 export const handleFetchError = (error: unknown) => {
   if (isFetchError(error)) {
+    Sentry.captureException(error);
+
     return (
       <div className="w-full grow flex flex-col justify-center items-center gap-3.5 p-5">
         {getFetchFallbackByStatus(error)}


### PR DESCRIPTION
## #️⃣연관된 이슈

#113

## 📝작업 내용

- sentry 적용
- 404 페이지 추가
- ErrorBoundary 방식 수정
  - `react-error-boundary` => `sentry.Errorboundary` 사용 
  - main, mothweek, chart : DateControlHeader를 사용하는 페이지는 데이터 페칭 문제로 `ErrorBoundary`를 사용하지 않고 컴포넌트 내부에서 `handleFetchError`로 에러 핸들링