### PR TITLE
Hotfix: 반복 가계부 편집 오류 수정 및 모바일 UI 최적화

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -7,7 +7,7 @@ import { endpoints } from './endpoints';
 
 const apiClient = (() =>
   axios.create({
-    baseURL: import.meta.env.DEV ? '' : import.meta.env.VITE_API_BASE_URL,
+    baseURL: import.meta.env.VITE_API_BASE_URL,
     headers: {
       'Content-Type': 'application/json',
     },

--- a/src/components/modal/PWAInstallModal.tsx
+++ b/src/components/modal/PWAInstallModal.tsx
@@ -12,8 +12,7 @@ const PWAInstallModal = ({ closeModal }: Props) => {
   useEffect(() => {
     const userAgent = navigator.userAgent;
 
-    console.log(userAgent);
-    if (/iPhone|Mac|iPad|iPod/.test(userAgent)) {
+    if (/iPhone|iPad|iPod/.test(userAgent) || (userAgent.includes('Macintosh') && navigator.maxTouchPoints > 1)) {
       setDeviceType('ios');
     } else if (/Android/.test(userAgent)) {
       setDeviceType('android');

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,12 +10,12 @@ import { queryClient } from '@/libs/queryClient.ts';
 import GlobalErrorBoundary from '@/components/error/GlobalErrorBoundary.tsx';
 import './sentry';
 
-if (typeof window !== 'undefined') {
-  if (import.meta.env.DEV) {
-    const { worker } = await import('@/mocks/browser');
-    await worker.start();
-  }
-}
+// if (typeof window !== 'undefined') {
+//   if (import.meta.env.DEV) {
+//     const { worker } = await import('@/mocks/browser');
+//     await worker.start();
+//   }
+// }
 
 createRoot(document.getElementById('root')!).render(
   <QueryClientProvider client={queryClient}>

--- a/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
+++ b/src/pages/AddEditTransactionPage/components/TransactionForm.tsx
@@ -91,8 +91,6 @@ const TransactionForm = ({ openEdit, initialIterationTypeRef, isIterationModifie
     }
   };
 
-  console.log(isValid, hasDraftData);
-
   if (isGetTransactionFetching) {
     return (
       <div className="w-full flex grow items-center justify-center">

--- a/src/pages/ChartPage/components/period/PeriodComparisonChart.tsx
+++ b/src/pages/ChartPage/components/period/PeriodComparisonChart.tsx
@@ -43,16 +43,16 @@ const PeriodComparisonChart = () => {
   }
 
   return (
-    <div>
+    <div className="flex flex-col justify-between grow">
       <PeriodSummary
         currentTransactionType={currentTransactionType}
         currentReportType={currentReportType}
         differenceAmount={barChartData.differenceAmount}
         averageAmount={barChartData.averageAmount}
       />
-      <div className="w-full h-[250px] mb-4 flex justify-center items-center relative">
+      <div className="w-full h-[300px] mb-4 flex justify-center items-center relative">
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={barChartData.totalAmounts} margin={{ top: 20, right: 10, bottom: 0, left: 10 }}>
+          <BarChart data={barChartData.totalAmounts} margin={{ top: 40, right: 10, bottom: 0, left: 10 }}>
             <XAxis
               dataKey="period"
               type="category"

--- a/src/pages/ChartPage/components/period/PeriodComparisonCustomLabel.tsx
+++ b/src/pages/ChartPage/components/period/PeriodComparisonCustomLabel.tsx
@@ -6,7 +6,7 @@ const PeriodComparisonCustomLabel = (props: LabelProps) => {
   const numericY = Number(y);
   const numericWidth = Number(width);
 
-  const adjustedY = value === '0원' ? 215 : numericY - 10;
+  const adjustedY = value === '0원' ? 265 : numericY - 10;
 
   return (
     <text x={numericX + numericWidth / 2} y={adjustedY} fill="#000000" fontSize={14} textAnchor="middle">

--- a/src/pages/ChartPage/components/period/PeriodSummary.tsx
+++ b/src/pages/ChartPage/components/period/PeriodSummary.tsx
@@ -13,7 +13,7 @@ interface Props {
 const PeriodSummary = ({ currentTransactionType, currentReportType, differenceAmount, averageAmount }: Props) => {
   const { chartHeaderDate } = useHeaderDateStore();
   return (
-    <div className="p-5 mb-10">
+    <div className="p-5">
       <div className="text-xl">
         {format(chartHeaderDate, currentReportType === '월별' ? 'M' : 'yyyy')}
         {currentReportType === '월별' ? '월' : '년'}에는 {currentReportType === '월별' ? '전월' : '작년'}보다{' '}

--- a/src/pages/MainPage/components/daily/DailyTransactionList.tsx
+++ b/src/pages/MainPage/components/daily/DailyTransactionList.tsx
@@ -39,8 +39,8 @@ const DailyTransactionList = () => {
   return (
     <div
       className={clsx(
-        isEmpty && 'justify-center items-center',
-        'flex flex-col w-full min-h-[20rem] max-h-[25rem] items-center gap-5 border-t py-5 pb-7 border-strokeGray overflow-y-auto custom-scrollbar',
+        isEmpty ? 'justify-center items-center grow' : 'min-h-[20rem] max-h-[30rem] ',
+        'flex flex-col w-full items-center gap-5 border-t py-5 pb-7 border-strokeGray overflow-y-auto custom-scrollbar',
       )}>
       {isEmpty || !dailyDetails ? (
         <span className="text-defaultGrey">내역이 없습니다.</span>

--- a/src/schemas/customIterationSchema.ts
+++ b/src/schemas/customIterationSchema.ts
@@ -2,13 +2,15 @@ import { z } from 'zod';
 
 export const daysOfWeekEnum = z.enum(['월', '화', '수', '목', '금', '토', '일']);
 
+const modeEnum = z.enum(['dayOfMonth', 'weekdayOfMonth', 'endOfMonth']);
+
 const monthlyOptionSchema = z.discriminatedUnion('mode', [
   z.object({
-    mode: z.literal('dayOfMonth'),
+    mode: modeEnum,
     day: z.number(),
+    week: z.number().min(0).max(4),
+    dayOfWeek: daysOfWeekEnum,
   }),
-  z.object({ mode: z.literal('weekdayOfMonth'), week: z.number().min(0).max(4), dayOfWeek: daysOfWeekEnum }),
-  z.object({ mode: z.literal('endOfMonth') }),
 ]);
 
 const iterationRuleSchema = z.discriminatedUnion('type', [


### PR DESCRIPTION
## #️⃣연관된 이슈

#123

## 📝작업 내용

- 가계부 편집 오류 수정 : 사용자화 매월 반복이 지정된 가계부의 경우 가계부 추가시 관련 필드들을 모두 전송하고 가계부 조회시 해당 필드듣ㄹ을 내려받는 로직으로 수정
- 모바일 UI 최적화
