### PR TITLE
Feat : OAuth 및 회원정보 입력 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,11 +32,12 @@ function App() {
         <Route path="/login/id" element={<IDLoginPage />} />
         <Route path="/login/find-id" element={<FindUsernamePage />} />
         <Route path="/login/find-password" element={<FindPasswordPage />} />
-        <Route path="/onboarding/profile" element={<ProfileOnboardingPage />} />
         <Route path="/signup" element={<SignupPage />} />
       </Route>
       <Route element={<ProtectedRoute />}>
         <Route path="/" element={<MainPage />} />
+        <Route path="/onboarding/profile" element={<ProfileOnboardingPage />} />
+
         <Route path="/add-transaction" element={<AddTransactionPage />} />
         <Route path="/edit-transaction" element={<EditTransactionPage />} />
         <Route path="/categories" element={<CategoriesPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import EditTransactionPage from '@/pages/EditTransactionPage/EditTransactionPage
 import FindUsernamePage from '@/pages/FindUsernamePage/FindUsernamePage';
 import FindPasswordPage from '@/pages/FindPasswordPage/FindPasswordPage';
 import LoginChoicePage from '@/pages/LoginChoicePage/LoginChoicePage';
+import ProfileOnboardingPage from '@/pages/ProfileOnboardingPage/ProfileOnboardingPage';
 
 function App() {
   return (
@@ -31,6 +32,7 @@ function App() {
         <Route path="/login/id" element={<IDLoginPage />} />
         <Route path="/login/find-id" element={<FindUsernamePage />} />
         <Route path="/login/find-password" element={<FindPasswordPage />} />
+        <Route path="/onboarding/profile" element={<ProfileOnboardingPage />} />
         <Route path="/signup" element={<SignupPage />} />
       </Route>
       <Route element={<ProtectedRoute />}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,6 @@ function App() {
       <Route element={<ProtectedRoute />}>
         <Route path="/" element={<MainPage />} />
         <Route path="/onboarding/profile" element={<ProfileOnboardingPage />} />
-
         <Route path="/add-transaction" element={<AddTransactionPage />} />
         <Route path="/edit-transaction" element={<EditTransactionPage />} />
         <Route path="/categories" element={<CategoriesPage />} />

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -18,7 +18,7 @@ apiClient.interceptors.request.use(config => {
   const token = tokenManager.getToken();
 
   if (token) {
-    config.headers.Authorization = token;
+    config.headers.Authorization = `Bearer ${token}`;
   }
 
   if (config.data instanceof FormData) {

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -16,6 +16,7 @@ export const endpoints = {
     findUsername: '/user/username-recovery',
     verifyUser: '/user/verify-user',
     resetPassword: '/user/reset-password',
+    getUserRole: '/user/role',
   },
   email: {
     getUserEmail: '/user/email',

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -8,6 +8,8 @@ export const endpoints = {
     checkUsernameDuplicate: '/user/exists/username',
     refreshToken: '/auth/refresh',
     getUserDetails: '/user/detail',
+    getOnboardingUserDetails: '/user/oauth/profile',
+    updateOnboardingUserDetails: '/user/oauth/profile',
     updateUserDetails: '/user/update',
     updatePassword: '/user/password',
     dataReset: '/user/reset',

--- a/src/api/services/authService.ts
+++ b/src/api/services/authService.ts
@@ -16,6 +16,7 @@ import {
   FindUsernameRes,
   ResetPassword,
   OnboardingFormType,
+  UserRoleType,
 } from '@/types/authTypes';
 import { tokenManager } from '@/utils/tokenManager';
 
@@ -125,4 +126,9 @@ export const getOnboardingUserDetails = async () => {
 export const updateOnboardingUserDetails = async (body: FormData) => {
   const res = await fetchData<FormData>('PUT', endpoints.auth.updateOnboardingUserDetails, body);
   return res;
+};
+
+export const getUserRole = async () => {
+  const res = await fetchData<undefined, UserRoleType>('GET', endpoints.auth.getUserRole);
+  if (res.data) return res.data.role;
 };

--- a/src/api/services/authService.ts
+++ b/src/api/services/authService.ts
@@ -15,6 +15,7 @@ import {
   FindUsernameReq,
   FindUsernameRes,
   ResetPassword,
+  OnboardingFormType,
 } from '@/types/authTypes';
 import { tokenManager } from '@/utils/tokenManager';
 
@@ -113,5 +114,15 @@ export const findUsername = async (body: FindUsernameReq) => {
 
 export const resetPassword = async (body: ResetPassword) => {
   const res = await fetchData<ResetPassword>('POST', endpoints.auth.resetPassword, body);
+  return res;
+};
+
+export const getOnboardingUserDetails = async () => {
+  const res = await fetchData<undefined, OnboardingFormType>('GET', endpoints.auth.getOnboardingUserDetails);
+  return res.data;
+};
+
+export const updateOnboardingUserDetails = async (body: FormData) => {
+  const res = await fetchData<FormData>('PUT', endpoints.auth.updateOnboardingUserDetails, body);
   return res;
 };

--- a/src/components/button/SignButton.tsx
+++ b/src/components/button/SignButton.tsx
@@ -16,6 +16,7 @@ const SignButton = ({ label, onClick, isPending, disabled, type = 'button' }: Pr
         'w-full h-[3.6rem] rounded-lg text-md cursor-pointer flex items-center justify-center',
         (label === '아이디로 로그인' || label === '로그인') &&
           (disabled ? 'bg-strokeGray text-defaultGrey' : 'bg-pastelLime text-oliveGreen'),
+        label === '카카오로 로그인' && 'bg-[#FEE500] text-[#191919]',
         label === '회원가입' && 'bg-pinkRed text-sunsetRose',
       )}
       type={type}

--- a/src/components/route/ProtectedRoute.tsx
+++ b/src/components/route/ProtectedRoute.tsx
@@ -4,7 +4,7 @@ import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 const ProtectedRoute = () => {
   const isLogin = useAuthStatus();
-  const { data: userRole, isLoading: isUserRoleLoading } = useGetUserRole();
+  const { data: userRole, isLoading: isUserRoleLoading } = useGetUserRole({ enabled: isLogin === true });
   const location = useLocation();
 
   if (isLogin === null || isUserRoleLoading) return null;

--- a/src/components/route/ProtectedRoute.tsx
+++ b/src/components/route/ProtectedRoute.tsx
@@ -1,12 +1,25 @@
+import useGetUserRole from '@/hooks/apis/auth/useGetUserRole';
 import { useAuthStatus } from '@/hooks/useAuthStatus';
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 const ProtectedRoute = () => {
   const isLogin = useAuthStatus();
+  const { data: userRole, isLoading: isUserRoleLoading } = useGetUserRole();
+  const location = useLocation();
 
-  if (isLogin === null) return null;
+  if (isLogin === null || isUserRoleLoading) return null;
 
-  return isLogin ? <Outlet /> : <Navigate to="/login" replace />;
+  if (!isLogin) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const isOnboardingRoute = location.pathname === '/onboarding/profile';
+
+  if (userRole === 'PENDING' && !isOnboardingRoute) {
+    return <Navigate to="/onboarding/profile" replace />;
+  }
+
+  return <Outlet />;
 };
 
 export default ProtectedRoute;

--- a/src/hooks/apis/auth/useGetOnboardingUserDetails.ts
+++ b/src/hooks/apis/auth/useGetOnboardingUserDetails.ts
@@ -1,0 +1,11 @@
+import { getOnboardingUserDetails } from '@/api/services/authService';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetOnboardingUserDetails = () => {
+  return useQuery({
+    queryKey: ['onboardingUserDetails'],
+    queryFn: getOnboardingUserDetails,
+  });
+};
+
+export default useGetOnboardingUserDetails;

--- a/src/hooks/apis/auth/useGetUserRole.ts
+++ b/src/hooks/apis/auth/useGetUserRole.ts
@@ -1,10 +1,11 @@
 import { getUserRole } from '@/api/services/authService';
 import { useQuery } from '@tanstack/react-query';
 
-const useGetUserRole = () => {
+const useGetUserRole = (options = {}) => {
   return useQuery({
     queryKey: ['userRole'],
     queryFn: getUserRole,
+    ...options,
   });
 };
 

--- a/src/hooks/apis/auth/useGetUserRole.ts
+++ b/src/hooks/apis/auth/useGetUserRole.ts
@@ -1,0 +1,11 @@
+import { getUserRole } from '@/api/services/authService';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetUserRole = () => {
+  return useQuery({
+    queryKey: ['userRole'],
+    queryFn: getUserRole,
+  });
+};
+
+export default useGetUserRole;

--- a/src/hooks/apis/auth/useUpdateOnboardingUserDetails.ts
+++ b/src/hooks/apis/auth/useUpdateOnboardingUserDetails.ts
@@ -1,0 +1,29 @@
+import { updateOnboardingUserDetails } from '@/api/services/authService';
+import useNicknameVerification from '@/hooks/field/useNicknameVerification ';
+import { OnboardingFormType } from '@/types/authTypes';
+import CustomError from '@/utils/error/CustomError';
+import { createFormErrorHandler } from '@/utils/error/errorHandler';
+import { useMutation } from '@tanstack/react-query';
+import { UseFormSetError } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+const useUpdateOnboardingUserDetails = (setError: UseFormSetError<OnboardingFormType>) => {
+  const navigate = useNavigate();
+  const { resetNicknameStatus } = useNicknameVerification();
+  const handleProfileError = createFormErrorHandler(setError);
+
+  return useMutation({
+    mutationFn: updateOnboardingUserDetails,
+    onSuccess: () => {
+      navigate('/');
+    },
+    onError: error => {
+      if (error instanceof CustomError && error.data?.field === 'nickname') {
+        resetNicknameStatus();
+      }
+      handleProfileError(error);
+    },
+  });
+};
+
+export default useUpdateOnboardingUserDetails;

--- a/src/hooks/field/useUserProfileForm.ts
+++ b/src/hooks/field/useUserProfileForm.ts
@@ -7,23 +7,22 @@ import { OnboardingFormType, ProfileFormData } from '@/types/authTypes';
 type UseUserProfileFormParams<T extends FieldValues> = {
   getHook: () => { data?: T; isPending: boolean };
   updateHook: (setError: UseFormSetError<T>) => { mutate: (data: FormData) => void; isPending?: boolean };
-  setError: UseFormSetError<T>;
   checkChanged?: boolean;
 };
 
 export const useUserProfileForm = <TForm extends ProfileFormData | OnboardingFormType>({
   getHook,
   updateHook,
-  setError,
   checkChanged,
 }: UseUserProfileFormParams<TForm>) => {
-  const { data, isPending } = getHook();
-  const { mutate, isPending: isMutating } = updateHook(setError);
   const {
     reset,
     handleSubmit,
+    setError,
     formState: { isValid, dirtyFields },
   } = useFormContext<TForm>();
+  const { data, isPending } = getHook();
+  const { mutate, isPending: isMutating } = updateHook(setError);
 
   const { nicknameStatus } = useNicknameFieldStore();
   const isNicknameChanged = Boolean((dirtyFields as any).nickname);

--- a/src/hooks/field/useUserProfileForm.ts
+++ b/src/hooks/field/useUserProfileForm.ts
@@ -1,0 +1,76 @@
+import { useEffect } from 'react';
+import { FieldValues, useFormContext, UseFormSetError } from 'react-hook-form';
+import { useNicknameFieldStore } from '@/stores/fields/useNicknameFieldStore';
+import { filteredData } from '@/utils/form/filteredFormData';
+import { OnboardingFormType, ProfileFormData } from '@/types/authTypes';
+
+type UseUserProfileFormParams<T extends FieldValues> = {
+  getHook: () => { data?: T; isPending: boolean };
+  updateHook: (setError: UseFormSetError<T>) => { mutate: (data: FormData) => void; isPending?: boolean };
+  setError: UseFormSetError<T>;
+  checkChanged?: boolean;
+};
+
+export const useUserProfileForm = <TForm extends ProfileFormData | OnboardingFormType>({
+  getHook,
+  updateHook,
+  setError,
+  checkChanged,
+}: UseUserProfileFormParams<TForm>) => {
+  const { data, isPending } = getHook();
+  const { mutate, isPending: isMutating } = updateHook(setError);
+  const {
+    reset,
+    handleSubmit,
+    formState: { isValid, dirtyFields },
+  } = useFormContext<TForm>();
+
+  const { nicknameStatus } = useNicknameFieldStore();
+  const isNicknameChanged = Boolean((dirtyFields as any).nickname);
+  const isChanged = Object.keys(dirtyFields).length > 0;
+
+  const isDisabled = !isValid || (checkChanged && !isChanged) || (isNicknameChanged && !nicknameStatus.isVerify);
+
+  useEffect(() => {
+    if (data) {
+      const sanitized = {
+        ...data,
+        profileImage: (data as any).profileImage ?? undefined,
+      };
+      reset(sanitized);
+    }
+  }, [data, reset]);
+
+  const onSubmit = (formData: TForm) => {
+    const postData: Record<string, any> = { ...formData };
+
+    if ('profileImage' in dirtyFields) {
+      if (!formData.profileImage) {
+        postData.isDefaultProfile = true;
+      } else {
+        postData.isDefaultProfile = false;
+      }
+    } else {
+      delete postData.profileImage;
+    }
+
+    const requestData = filteredData(postData);
+    const form = new FormData();
+
+    Object.entries(requestData).forEach(([key, value]) => {
+      if (typeof value === 'boolean') {
+        value = String(value);
+      }
+      form.append(key, value);
+    });
+
+    mutate(form);
+  };
+
+  return {
+    isPending,
+    isMutating,
+    handleSubmit: handleSubmit(onSubmit),
+    isDisabled,
+  };
+};

--- a/src/mocks/handler/authHandlers.ts
+++ b/src/mocks/handler/authHandlers.ts
@@ -179,4 +179,17 @@ export const authHandlers = [
       { status: 201 },
     );
   }),
+
+  http.get(endpoints.auth.getUserRole, () => {
+    return HttpResponse.json(
+      {
+        status: 200,
+        message: '사용자 역할 조회 성공',
+        data: {
+          role: 'PENDING',
+        },
+      },
+      { status: 200 },
+    );
+  }),
 ];

--- a/src/mocks/handler/authHandlers.ts
+++ b/src/mocks/handler/authHandlers.ts
@@ -12,6 +12,7 @@ import {
 } from '@/mocks/constants/auth';
 import Cookies from 'js-cookie';
 import { ChangePasswordData } from '@/types/authTypes';
+import { createMockRefreshToken } from '../utils/createMockToken';
 
 export const authHandlers = [
   http.post(endpoints.auth.checkUsernameDuplicate, async ({ request }) => {
@@ -144,6 +145,36 @@ export const authHandlers = [
         data: {
           username: 'test',
         },
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.get(endpoints.auth.getOnboardingUserDetails, () => {
+    return HttpResponse.json(
+      {
+        status: 200,
+        message: '회원 상세 조회 성공',
+        data: {
+          profileImage: '어쩌구url',
+          isDefaultProfile: false,
+          name: '홍길동',
+          nickname: 'happy123',
+          birth: '2025-07-14',
+          gender: 'MALE',
+          job: '무직',
+        },
+      },
+      { status: 200 },
+    );
+  }),
+
+  http.put(endpoints.auth.updateOnboardingUserDetails, () => {
+    Cookies.set('refreshToken', createMockRefreshToken(), { expires: 7 });
+    return HttpResponse.json(
+      {
+        status: 201,
+        message: '회원 정보 추가 성공',
       },
       { status: 201 },
     );

--- a/src/pages/LoginChoicePage/LoginChoicePage.tsx
+++ b/src/pages/LoginChoicePage/LoginChoicePage.tsx
@@ -4,13 +4,18 @@ import { useNavigate } from 'react-router-dom';
 
 const LoginChoicePage = () => {
   const navigate = useNavigate();
+
   return (
     <div className="flex flex-col h-screen items-center justify-center bg-vanillaCream">
       <div className="flex flex-col w-full grow items-center justify-center gap-36">
         <img src={Logo} alt="로고 이미지" className="w-[20rem] aspect-square" />
         <div className="flex flex-col w-3/5 gap-5">
           <SignButton label="로그인" type="button" onClick={() => navigate('/login/id')} />
-          <SignButton label="카카오로 로그인" type="button" onClick={() => navigate('/login/id')} />
+          <SignButton
+            label="카카오로 로그인"
+            type="button"
+            onClick={() => (window.location.href = import.meta.env.VITE_KAKAO_AUTH_URL)}
+          />
         </div>
       </div>
     </div>

--- a/src/pages/ProfileOnboardingPage/ProfileOnboardingPage.tsx
+++ b/src/pages/ProfileOnboardingPage/ProfileOnboardingPage.tsx
@@ -1,0 +1,24 @@
+import DefaultHeader from '@/components/header/DefaultHeader';
+import { FormProvider, useForm } from 'react-hook-form';
+import OnboardingProfileForm from '@/pages/ProfileOnboardingPage/components/OnboardingProfileForm';
+import { onboardingProfileSchema } from '@/schemas/authSchema';
+import { OnboardingFormType } from '@/types/authTypes';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+const ProfileOnboardingPage = () => {
+  const methods = useForm<OnboardingFormType>({
+    resolver: zodResolver(onboardingProfileSchema),
+    mode: 'onChange',
+  });
+
+  return (
+    <div className="flex flex-col w-full min-h-screen">
+      <DefaultHeader label="회원정보 입력" />
+      <FormProvider {...methods}>
+        <OnboardingProfileForm />
+      </FormProvider>
+    </div>
+  );
+};
+
+export default ProfileOnboardingPage;

--- a/src/pages/ProfileOnboardingPage/components/OnboardingProfileForm.tsx
+++ b/src/pages/ProfileOnboardingPage/components/OnboardingProfileForm.tsx
@@ -1,0 +1,51 @@
+import PrimaryButton from '@/components/button/PrimaryButton';
+import BirthField from '@/components/input/auth/BirthField';
+import GenderField from '@/components/input/auth/GenderField';
+import JobField from '@/components/input/auth/JobField';
+import NameField from '@/components/input/auth/NameField';
+import NicknameField from '@/components/input/auth/NicknameField';
+import ProfileImageField from '@/components/input/auth/ProfileImageField';
+import LoadingSpinner from '@/components/loading/LoadingSpinner';
+import useGetOnboardingUserDetails from '@/hooks/apis/auth/useGetOnboardingUserDetails';
+import useUpdateOnboardingUserDetails from '@/hooks/apis/auth/useUpdateOnboardingUserDetails';
+import { useUserProfileForm } from '@/hooks/field/useUserProfileForm';
+import { OnboardingFormType } from '@/types/authTypes';
+
+const OnboardingProfileForm = () => {
+  const {
+    isPending: isGetOnboardingUserDetails,
+    isMutating: isUpdateOnboardingUserDetails,
+    handleSubmit,
+    isDisabled,
+  } = useUserProfileForm<OnboardingFormType>({
+    getHook: useGetOnboardingUserDetails,
+    updateHook: useUpdateOnboardingUserDetails,
+  });
+
+  if (isGetOnboardingUserDetails)
+    return (
+      <div className="w-full flex grow justify-center items-center">
+        <LoadingSpinner size={30} />
+      </div>
+    );
+
+  return (
+    <form className="flex flex-col justify-between grow px-5 pt-15 pb-8" onSubmit={handleSubmit}>
+      <div className="w-full flex flex-col">
+        <ProfileImageField />
+        <div className="flex flex-col gap-3 my-15">
+          <NameField />
+          <NicknameField />
+          <BirthField />
+          <GenderField />
+          <JobField />
+        </div>
+      </div>
+      <div className="w-full flex justify-end">
+        <PrimaryButton label="저장" type="submit" disabled={isDisabled} isPending={isUpdateOnboardingUserDetails} />
+      </div>
+    </form>
+  );
+};
+
+export default OnboardingProfileForm;

--- a/src/pages/ProfilePage/components/ProfileForm.tsx
+++ b/src/pages/ProfilePage/components/ProfileForm.tsx
@@ -7,7 +7,6 @@ import JobField from '@/components/input/auth/JobField';
 import PrimaryButton from '@/components/button/PrimaryButton';
 import useModal from '@/hooks/useModal';
 import DefaultModal from '@/components/modal/DefaultModal';
-import { useFormContext } from 'react-hook-form';
 import { ProfileFormData } from '@/types/authTypes';
 import DeleteUserButton from '@/pages/ProfilePage/components/DeleteUserButton';
 import useDeleteUser from '@/hooks/apis/auth/useDeleteUser';
@@ -17,7 +16,6 @@ import LoadingSpinner from '@/components/loading/LoadingSpinner';
 import { useUserProfileForm } from '@/hooks/field/useUserProfileForm';
 
 const ProfileForm = () => {
-  const { setError } = useFormContext<ProfileFormData>();
   const { isOpen, openModal, closeModal } = useModal();
   const { mutate: deleteUser } = useDeleteUser();
 
@@ -29,7 +27,6 @@ const ProfileForm = () => {
   } = useUserProfileForm<ProfileFormData>({
     getHook: useGetUserDetails,
     updateHook: useUpdateUserDetails,
-    setError,
     checkChanged: true,
   });
 

--- a/src/pages/ProfilePage/components/ProfileForm.tsx
+++ b/src/pages/ProfilePage/components/ProfileForm.tsx
@@ -8,68 +8,30 @@ import PrimaryButton from '@/components/button/PrimaryButton';
 import useModal from '@/hooks/useModal';
 import DefaultModal from '@/components/modal/DefaultModal';
 import { useFormContext } from 'react-hook-form';
-import { ProfileFormData, ProfileUpdateFormData } from '@/types/authTypes';
+import { ProfileFormData } from '@/types/authTypes';
 import DeleteUserButton from '@/pages/ProfilePage/components/DeleteUserButton';
 import useDeleteUser from '@/hooks/apis/auth/useDeleteUser';
 import useGetUserDetails from '@/hooks/apis/auth/useGetUserDetails';
-import { useEffect } from 'react';
 import useUpdateUserDetails from '@/hooks/apis/auth/useUpdateUserDetails';
-import { filteredData } from '@/utils/form/filteredFormData';
 import LoadingSpinner from '@/components/loading/LoadingSpinner';
-import { useNicknameFieldStore } from '@/stores/fields/useNicknameFieldStore';
+import { useUserProfileForm } from '@/hooks/field/useUserProfileForm';
 
 const ProfileForm = () => {
-  const {
-    reset,
-    handleSubmit,
-    setError,
-    formState: { isValid, dirtyFields },
-  } = useFormContext<ProfileFormData>();
+  const { setError } = useFormContext<ProfileFormData>();
   const { isOpen, openModal, closeModal } = useModal();
-
   const { mutate: deleteUser } = useDeleteUser();
-  const { mutate: updateUserDetails, isPending: isUpdateUserDetailsPending } = useUpdateUserDetails(setError);
-  const { data: userDetails, isPending: isGetUserDetailsPending } = useGetUserDetails();
-  const { nicknameStatus } = useNicknameFieldStore();
-  const isNicknameChanged = Boolean(dirtyFields.nickname);
-  const isChanged = Object.keys(dirtyFields).length > 0;
 
-  const onSubmit = (data: ProfileFormData) => {
-    let postData: ProfileUpdateFormData = { ...data };
-
-    if (dirtyFields.profileImage) {
-      if (!data.profileImage) {
-        postData = { ...postData, isDefaultProfile: true };
-      } else {
-        postData = { ...postData, isDefaultProfile: false };
-      }
-    } else {
-      delete postData.profileImage;
-    }
-
-    const requestData = filteredData(postData);
-
-    const formData = new FormData();
-
-    Object.entries(requestData).forEach(([key, value]) => {
-      if (typeof value === 'boolean') {
-        value = String(value);
-      }
-      formData.append(key, value);
-    });
-
-    updateUserDetails(formData);
-  };
-
-  useEffect(() => {
-    if (userDetails) {
-      const sanitizedData = {
-        ...userDetails,
-        profileImage: userDetails.profileImage ?? undefined,
-      };
-      reset(sanitizedData);
-    }
-  }, [reset, userDetails]);
+  const {
+    isPending: isGetUserDetailsPending,
+    isMutating: isUpdateUserDetailsPending,
+    handleSubmit,
+    isDisabled,
+  } = useUserProfileForm<ProfileFormData>({
+    getHook: useGetUserDetails,
+    updateHook: useUpdateUserDetails,
+    setError,
+    checkChanged: true,
+  });
 
   if (isGetUserDetailsPending)
     return (
@@ -80,7 +42,7 @@ const ProfileForm = () => {
 
   return (
     <>
-      <form className="flex flex-col justify-between grow px-5 pt-15 pb-8" onSubmit={handleSubmit(onSubmit)}>
+      <form className="flex flex-col justify-between grow px-5 pt-15 pb-8" onSubmit={handleSubmit}>
         <div className="w-full flex flex-col">
           <ProfileImageField />
           <div className="flex flex-col gap-3 my-15">
@@ -93,12 +55,7 @@ const ProfileForm = () => {
         </div>
         <div className="w-full flex items-center justify-between">
           <DeleteUserButton openModal={openModal} />
-          <PrimaryButton
-            label="저장"
-            type="submit"
-            disabled={!isValid || !isChanged || (isNicknameChanged && !nicknameStatus.isVerify)}
-            isPending={isUpdateUserDetailsPending}
-          />
+          <PrimaryButton label="저장" type="submit" disabled={isDisabled} isPending={isUpdateUserDetailsPending} />
         </div>
       </form>
       {isOpen && <DefaultModal content="회원탈퇴를 하시겠습니까?" onClick={deleteUser} onClose={closeModal} />}

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -60,6 +60,19 @@ export const profileSchema = baseSignupSchema
     isDefaultProfile: z.boolean(),
   });
 
+export const onboardingProfileSchema = baseSignupSchema
+  .pick({
+    profileImage: true,
+    name: true,
+    nickname: true,
+    birth: true,
+    gender: true,
+    job: true,
+  })
+  .extend({
+    isDefaultProfile: z.boolean(),
+  });
+
 export const changePasswordSchema = passwordMatchRefinement(
   z.object({
     currentPassword: z.string({ message: '비밀번호를 입력해주세요' }),

--- a/src/types/authTypes.ts
+++ b/src/types/authTypes.ts
@@ -5,12 +5,15 @@ import {
   findUserForPasswordSchema,
   findUsernameSchema,
   loginSchema,
+  onboardingProfileSchema,
   profileSchema,
   resetPasswordSchema,
   signupSchema,
 } from '@/schemas/authSchema';
 
 export type SignupFormType = z.infer<typeof signupSchema>;
+
+export type OnboardingFormType = z.infer<typeof onboardingProfileSchema>;
 
 export type UsernameDuplicationReq = {
   username: string;

--- a/src/types/authTypes.ts
+++ b/src/types/authTypes.ts
@@ -43,6 +43,10 @@ export const emailPurposeList = ['register', 'changeEmail', 'findUsername', 'cha
 
 export type EmailPurposeType = (typeof emailPurposeList)[number];
 
+export type UserRoleType = {
+  role: 'USER' | 'ADMIN' | 'TEST' | 'PENDING';
+};
+
 export type SendEmailReq = { email: string; purpose: EmailPurposeType; username?: string };
 
 export type EmailRes = { notificationMessage: string };


### PR DESCRIPTION
## #️⃣연관된 이슈

#148

## 📝작업 내용

- OAuth 카카오 로그인 기능 추가
- 카카오 로그인 후 추가적으로 필요한 회원 정보를 받는 페이지 추가
- `<ProtectedRoute/>` 에서 유저 역할로 페이지 분기 처리
  - 사용자의 역할을 조회해서 `PENDING` 상태인 경우 =>  `회원 정보 입력 페이지`
  - `PEDNDING` 이 외의 상태인 경우 => `메인 페이지`
