### PR TITLE
Hotfix: 토큰 재발급 로직 오류

### DIFF
--- a/src/api/services/authService.ts
+++ b/src/api/services/authService.ts
@@ -18,6 +18,7 @@ import {
   OnboardingFormType,
   UserRoleType,
 } from '@/types/authTypes';
+import CustomError from '@/utils/error/CustomError';
 import { tokenManager } from '@/utils/tokenManager';
 
 export const checkUsernameDuplication = async ({ username }: UsernameDuplicationReq) => {
@@ -77,11 +78,13 @@ export const deleteUser = async () => {
 export const refreshToken = async () => {
   const res = await fetchData<undefined, TokenRes>('POST', endpoints.auth.refreshToken);
 
-  if (res.data) {
+  if (res.data?.accessToken) {
     const newToken = res.data.accessToken;
     tokenManager.setToken(newToken);
     return newToken;
   }
+
+  throw new CustomError('access token 재발급 실패', 401);
 };
 
 export const getUserDetails = async () => {

--- a/src/hooks/apis/auth/useUpdateOnboardingUserDetails.ts
+++ b/src/hooks/apis/auth/useUpdateOnboardingUserDetails.ts
@@ -6,15 +6,18 @@ import { createFormErrorHandler } from '@/utils/error/errorHandler';
 import { useMutation } from '@tanstack/react-query';
 import { UseFormSetError } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
+import useGetUserRole from './useGetUserRole';
 
 const useUpdateOnboardingUserDetails = (setError: UseFormSetError<OnboardingFormType>) => {
   const navigate = useNavigate();
   const { resetNicknameStatus } = useNicknameVerification();
   const handleProfileError = createFormErrorHandler(setError);
+  const { refetch: refetchUserRole } = useGetUserRole({ enabled: false });
 
   return useMutation({
     mutationFn: updateOnboardingUserDetails,
-    onSuccess: () => {
+    onSuccess: async () => {
+      await refetchUserRole();
       navigate('/');
     },
     onError: error => {

--- a/src/utils/error/isFetchError.ts
+++ b/src/utils/error/isFetchError.ts
@@ -5,6 +5,7 @@ export const isFetchError = (error: unknown): error is CustomError => {
     error instanceof CustomError &&
     typeof error.statusCode === 'number' &&
     error.statusCode >= 400 &&
-    error.statusCode < 500
+    error.statusCode < 500 &&
+    error.statusCode !== 401
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

#150 

## 📝작업 내용

### 오류 
: 사용자가 브라우저 탭을 오래 방치 했다가 다시 돌아 왔을 때 401 에러와 함께 로그인 페이지로 이동 되는 오류

<br/>

< 오류 시나리오 >
1. 사용자가 브라우저를 켜두고 다른 탭/앱으로 전환
2. 수 분 또는 수 시간이 흐름 → 브라우저 메모리 절약으로 토큰 변수가 null 이 됨.
3. 다시 탭으로 돌아옴 → React Query가 포그라운드 이벤트를 감지함
4. ProtectedRoute 로직이 재실행 되는데 이때 401 에러 발생으로 로그인 페이지로 이동하는 것으로 추정

<br/>

### 수정 
- hasToken 조건으로 토큰 갱신 로직이 실행되지 않는 문제를 해결하기위해 hasToken 옵션 제거 => 서버에서 액세스 토큰이 없을 때 쿠키를 삭제해주는 로직을 없애줌 => 쿠키는 유지하고 401 에러만 발생
- 토큰 갱신 중 중복 요청 방지를 위한 요청 큐 처리 : 401 에러가 발생하고 `refreshToken()` 요청을 중복으로 발생시키지 않기 위해 큐를 두어서 관리
