### PR TITLE
Feat: 지갑봉합소 퍼블리싱 및 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ const FindUsernamePage = lazy(() => import('@/pages/FindUsernamePage/FindUsernam
 const FindPasswordPage = lazy(() => import('@/pages/FindPasswordPage/FindPasswordPage'));
 const LoginChoicePage = lazy(() => import('@/pages/LoginChoicePage/LoginChoicePage'));
 const ProfileOnboardingPage = lazy(() => import('@/pages/ProfileOnboardingPage/ProfileOnboardingPage'));
+const ChatLobbyPage = lazy(() => import('@/pages/ChatLobbyPage/ChatLobbyPage'));
 
 function App() {
   return (
@@ -59,6 +60,7 @@ function App() {
           <Route path="/iteration-data" element={<IterationDataPage />} />
           <Route path="/chart" element={<ChartPage />} />
           <Route path="/chart/category-details/:categoryId" element={<CategoryDetailsPage />} />
+          <Route path="/chat" element={<ChatLobbyPage />} />
         </Route>
         <Route path="*" element={<ErrorPage />} />
       </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ const FindPasswordPage = lazy(() => import('@/pages/FindPasswordPage/FindPasswor
 const LoginChoicePage = lazy(() => import('@/pages/LoginChoicePage/LoginChoicePage'));
 const ProfileOnboardingPage = lazy(() => import('@/pages/ProfileOnboardingPage/ProfileOnboardingPage'));
 const ChatLobbyPage = lazy(() => import('@/pages/ChatLobbyPage/ChatLobbyPage'));
+const JoinedChatroomsEditPage = lazy(() => import('@/pages/JoinedChatroomsEditPage/JoinedChatroomsEditPage'));
 
 function App() {
   return (
@@ -61,6 +62,7 @@ function App() {
           <Route path="/chart" element={<ChartPage />} />
           <Route path="/chart/category-details/:categoryId" element={<CategoryDetailsPage />} />
           <Route path="/chat" element={<ChatLobbyPage />} />
+          <Route path="/chat/edit" element={<JoinedChatroomsEditPage />} />
         </Route>
         <Route path="*" element={<ErrorPage />} />
       </Routes>

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -85,7 +85,7 @@ apiClient.interceptors.response.use(
 );
 
 export const fetchData = async <RequestType = undefined, ResponseDataType = undefined, ErrorType = unknown>(
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
   endpoint: string,
   data?: RequestType,
   config?: AxiosRequestConfig,
@@ -102,6 +102,9 @@ export const fetchData = async <RequestType = undefined, ResponseDataType = unde
         break;
       case 'PUT':
         response = await apiClient.put(endpoint, data, config);
+        break;
+      case 'PATCH':
+        response = await apiClient.patch(endpoint, data, config);
         break;
       case 'DELETE':
         response = await apiClient.delete(endpoint, {

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -78,5 +78,6 @@ export const endpoints = {
       `/chatrooms?sortBy=${sortBy}${cursor ? `&cursor=${cursor}` : ''}`,
     getJoinedChatrooms: (cursor?: string | null) => `/users/me/chatrooms${cursor ? `?cursor=${cursor}` : ''}`,
     markAllAsRead: '/chatrooms/read-all',
+    leaveMultipleChatrooms: '/chatrooms/leave',
   },
 };

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1,3 +1,5 @@
+import { ChatroomSortParam } from '@/types/chatTypes';
+
 export const endpoints = {
   auth: {
     signup: '/user/register',
@@ -70,5 +72,10 @@ export const endpoints = {
     getVerticalBarChart: (categoryId: string, date: string) => `/chart/${categoryId}/vertical?date=${date}`,
     getCategoryLogs: (categoryId: string, date: string, cursor: string | null, isDescending: boolean) =>
       `/chart/${categoryId}/section?date=${date}${cursor ? `&cursor=${cursor}` : ''}${isDescending ? '' : '&sortDirection=DESC'}`,
+  },
+  chat: {
+    getAllChatrooms: (sortBy: ChatroomSortParam, cursor?: string | null) =>
+      `/chatrooms?sortBy=${sortBy}${cursor ? `&cursor=${cursor}` : ''}`,
+    getJoinedChatrooms: (cursor?: string | null) => `/users/me/chatrooms${cursor ? `?cursor=${cursor}` : ''}`,
   },
 };

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -77,5 +77,6 @@ export const endpoints = {
     getAllChatrooms: (sortBy: ChatroomSortParam, cursor?: string | null) =>
       `/chatrooms?sortBy=${sortBy}${cursor ? `&cursor=${cursor}` : ''}`,
     getJoinedChatrooms: (cursor?: string | null) => `/users/me/chatrooms${cursor ? `?cursor=${cursor}` : ''}`,
+    markAllAsRead: '/chatrooms/read-all',
   },
 };

--- a/src/api/services/chatService.ts
+++ b/src/api/services/chatService.ts
@@ -1,0 +1,15 @@
+import { fetchData } from '@/api/axios';
+import { endpoints } from '@/api/endpoints';
+import { AllChatroomsRes, ChatroomSortParam, JoinedChatroomsRes } from '@/types/chatTypes';
+
+export const getAllChatrooms = async (sortBy: ChatroomSortParam, cursor?: string | null) => {
+  const res = await fetchData<undefined, AllChatroomsRes>('GET', endpoints.chat.getAllChatrooms(sortBy, cursor));
+  if (!res.data) throw new Error('No Data');
+  return res.data;
+};
+
+export const getJoinedChatrooms = async (cursor?: string | null) => {
+  const res = await fetchData<undefined, JoinedChatroomsRes>('GET', endpoints.chat.getJoinedChatrooms(cursor));
+  if (!res.data) throw new Error('No Data');
+  return res.data;
+};

--- a/src/api/services/chatService.ts
+++ b/src/api/services/chatService.ts
@@ -13,3 +13,8 @@ export const getJoinedChatrooms = async (cursor?: string | null) => {
   if (!res.data) throw new Error('No Data');
   return res.data;
 };
+
+export const markAllChatroomsAsRead = async () => {
+  const res = await fetchData<undefined, undefined>('PATCH', endpoints.chat.markAllAsRead);
+  return res.data;
+};

--- a/src/api/services/chatService.ts
+++ b/src/api/services/chatService.ts
@@ -1,6 +1,12 @@
 import { fetchData } from '@/api/axios';
 import { endpoints } from '@/api/endpoints';
-import { AllChatroomsRes, ChatroomSortParam, JoinedChatroomsRes } from '@/types/chatTypes';
+import {
+  AllChatroomsRes,
+  ChatroomSortParam,
+  JoinedChatroomsRes,
+  leaveMultipleChatroomsReq,
+  leaveMultipleChatroomsRes,
+} from '@/types/chatTypes';
 
 export const getAllChatrooms = async (sortBy: ChatroomSortParam, cursor?: string | null) => {
   const res = await fetchData<undefined, AllChatroomsRes>('GET', endpoints.chat.getAllChatrooms(sortBy, cursor));
@@ -16,5 +22,14 @@ export const getJoinedChatrooms = async (cursor?: string | null) => {
 
 export const markAllChatroomsAsRead = async () => {
   const res = await fetchData<undefined, undefined>('PATCH', endpoints.chat.markAllAsRead);
+  return res.data;
+};
+
+export const leaveMultipleChatrooms = async (body: leaveMultipleChatroomsReq) => {
+  const res = await fetchData<leaveMultipleChatroomsReq, leaveMultipleChatroomsRes>(
+    'DELETE',
+    endpoints.chat.leaveMultipleChatrooms,
+    body,
+  );
   return res.data;
 };

--- a/src/components/button/ChatActionButton.tsx
+++ b/src/components/button/ChatActionButton.tsx
@@ -7,9 +7,10 @@ interface Props {
   isPending?: boolean;
   hasPassword?: boolean;
   disabled?: boolean;
+  onClick?: () => void;
 }
 
-const ChatActionButton = ({ label, isPending, hasPassword, disabled, ...rest }: Props) => {
+const ChatActionButton = ({ label, isPending, hasPassword, disabled, onClick }: Props) => {
   const { colorClass, spinnerColor } = (() => {
     if (label === '채팅 참여하기' || label === '참여중인 채팅방') {
       return { colorClass: 'bg-lightBlue text-oceanBlue', spinnerColor: '#81aaf6' };
@@ -27,7 +28,7 @@ const ChatActionButton = ({ label, isPending, hasPassword, disabled, ...rest }: 
         disabled ? 'bg-strokeGray text-defaultGrey' : colorClass,
       )}
       disabled={isPending || disabled}
-      {...rest}>
+      onClick={onClick}>
       <div className="flex items-center gap-2">
         {hasPassword && <LockKeyIcon />}
         <span className={isPending ? 'invisible' : 'visible'}>{label}</span>

--- a/src/components/button/ChatroomSortOptions.tsx
+++ b/src/components/button/ChatroomSortOptions.tsx
@@ -14,7 +14,7 @@ const ChatroomSortOptions = ({ sortOption, onClick }: Props) => {
   ];
 
   return (
-    <div className="flex gap-5 mx-2.5 mt-2.5">
+    <div className="flex gap-5 mx-7">
       {options.map(({ label, value }) => (
         <button
           key={value}

--- a/src/components/button/ChatroomSortOptions.tsx
+++ b/src/components/button/ChatroomSortOptions.tsx
@@ -17,6 +17,7 @@ const ChatroomSortOptions = ({ sortOption, onClick }: Props) => {
     <div className="flex gap-5 mx-2.5 mt-2.5">
       {options.map(({ label, value }) => (
         <button
+          key={value}
           onClick={() => onClick(value)}
           className={clsx('py-2 text-md cursor-pointer', value === sortOption ? 'text-black' : 'text-defaultGrey')}>
           {label}

--- a/src/components/button/ChatroomSortOptions.tsx
+++ b/src/components/button/ChatroomSortOptions.tsx
@@ -1,20 +1,23 @@
+import { ChatroomSortOptionValue } from '@/types/chatTypes';
 import clsx from 'clsx';
-import { useState } from 'react';
 
-const ChatroomSortOptions = () => {
-  const [sortOption, setSortOption] = useState<'likes' | 'createdAt' | 'popularity'>('createdAt');
+interface Props {
+  sortOption: ChatroomSortOptionValue;
+  onClick: (value: ChatroomSortOptionValue) => void;
+}
 
-  const options: { label: '인기순' | '최근 생성순' | '좋아요순'; value: 'likes' | 'createdAt' | 'popularity' }[] = [
+const ChatroomSortOptions = ({ sortOption, onClick }: Props) => {
+  const options: { label: '인기순' | '최근 생성순' | '좋아요순'; value: ChatroomSortOptionValue }[] = [
     { label: '인기순', value: 'popularity' },
     { label: '최근 생성순', value: 'createdAt' },
     { label: '좋아요순', value: 'likes' },
   ];
 
   return (
-    <div className="flex gap-5">
+    <div className="flex gap-5 mx-2.5 mt-2.5">
       {options.map(({ label, value }) => (
         <button
-          onClick={() => setSortOption(value)}
+          onClick={() => onClick(value)}
           className={clsx('py-2 text-md cursor-pointer', value === sortOption ? 'text-black' : 'text-defaultGrey')}>
           {label}
         </button>

--- a/src/components/button/icon/ChatroomSettingsButton.tsx
+++ b/src/components/button/icon/ChatroomSettingsButton.tsx
@@ -1,6 +1,13 @@
-const ChatroomSettingsButton = () => {
+import { forwardRef } from 'react';
+
+interface Props {
+  isMenuOpen?: boolean;
+  onClick?: () => void;
+}
+
+const ChatroomSettingsButton = forwardRef<HTMLButtonElement, Props>(({ isMenuOpen, onClick }, ref) => {
   return (
-    <button className="w-fit h-full cursor-pointer">
+    <button ref={ref} onClick={onClick} className={`${isMenuOpen && 'opacity-30'} w-fit h-full cursor-pointer`}>
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
           fill-rule="evenodd"
@@ -17,6 +24,6 @@ const ChatroomSettingsButton = () => {
       </svg>
     </button>
   );
-};
+});
 
 export default ChatroomSettingsButton;

--- a/src/components/button/modal/ModalButton.tsx
+++ b/src/components/button/modal/ModalButton.tsx
@@ -2,10 +2,17 @@ import AsyncButtonBase from '@/components/button/AsyncButtonBase';
 import { AsyncButtonBaseProps } from '@/types/propsTypes';
 import clsx from 'clsx';
 
-const ModalButton = ({ disabled, ...rest }: AsyncButtonBaseProps) => {
+const ModalButton = ({ disabled, isPending, ...rest }: AsyncButtonBaseProps) => {
   const colorStyle = disabled ? 'bg-strokeGray text-defaultGrey' : 'bg-pastelLime text-oliveGreen';
 
-  return <AsyncButtonBase {...rest} className={clsx('min-w-[9rem] px-8 h-[3.5rem]', colorStyle)} />;
+  return (
+    <AsyncButtonBase
+      disabled={disabled}
+      isPending={isPending}
+      {...rest}
+      className={clsx('min-w-[9rem] px-8 h-[3.5rem]', colorStyle)}
+    />
+  );
 };
 
 export default ModalButton;

--- a/src/components/button/toggle/ChatroomViewModeToggle.tsx
+++ b/src/components/button/toggle/ChatroomViewModeToggle.tsx
@@ -1,10 +1,13 @@
+import { ChatroomViewModeValue } from '@/types/chatTypes';
 import clsx from 'clsx';
-import { useState } from 'react';
 
-const ChatroomViewModeToggle = () => {
-  const [viewMode, setViewMode] = useState<'all' | 'joined'>('all');
+interface Props {
+  viewMode: ChatroomViewModeValue;
+  onClick: (value: ChatroomViewModeValue) => void;
+}
 
-  const options: { label: '전체' | '참여중인 채팅방'; value: 'all' | 'joined' }[] = [
+const ChatroomViewModeToggle = ({ viewMode, onClick }: Props) => {
+  const options: { label: '전체' | '참여중인 채팅방'; value: ChatroomViewModeValue }[] = [
     { label: '전체', value: 'all' },
     { label: '참여중인 채팅방', value: 'joined' },
   ];
@@ -13,9 +16,9 @@ const ChatroomViewModeToggle = () => {
     <div className="flex gap-4">
       {options.map(({ label, value }) => (
         <button
-          onClick={() => setViewMode(value)}
+          onClick={() => onClick(value)}
           className={clsx(
-            'px-5 py-2 border text-md rounded-4xl cursor-pointer',
+            'px-5 py-1 border text-md rounded-4xl cursor-pointer',
             value === viewMode ? 'border-oliveGreen bg-oliveGreen text-white' : 'border-strokeGray bg-white text-black',
           )}>
           {label}

--- a/src/components/button/toggle/ChatroomViewModeToggle.tsx
+++ b/src/components/button/toggle/ChatroomViewModeToggle.tsx
@@ -16,6 +16,7 @@ const ChatroomViewModeToggle = ({ viewMode, onClick }: Props) => {
     <div className="flex gap-4">
       {options.map(({ label, value }) => (
         <button
+          key={value}
           onClick={() => onClick(value)}
           className={clsx(
             'px-5 py-1 border text-md rounded-4xl cursor-pointer',

--- a/src/components/chatroom/JoinedChatroomList.tsx
+++ b/src/components/chatroom/JoinedChatroomList.tsx
@@ -19,7 +19,7 @@ const JoinedChatroomList = ({ isEditMode, selectedChatrooms, onClick }: Props) =
   useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
 
   return (
-    <div className="flex flex-col flex-grow gap-5 pt-7">
+    <div className="flex flex-col flex-grow gap-5 px-7 py-4">
       {isEmpty ? (
         <div className="flex-grow flex items-center justify-center text-defaultGrey">참여중인 채팅방이 없습니다</div>
       ) : (

--- a/src/components/chatroom/JoinedChatroomList.tsx
+++ b/src/components/chatroom/JoinedChatroomList.tsx
@@ -19,16 +19,21 @@ const JoinedChatroomList = ({ isEditMode, selectedChatrooms, onClick }: Props) =
   useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
 
   return (
-    <div className="flex-grow flex flex-col gap-5 pt-7">
-      {joinedChatrooms.map(chatroom => (
-        <JoinedChatroomItem
-          key={chatroom.chatroomId}
-          {...chatroom}
-          isEditMode={isEditMode}
-          isChecked={selectedChatrooms?.some(room => room.id === chatroom.chatroomId)}
-          onClick={() => onClick(chatroom.chatroomId, chatroom.isHost)}
-        />
-      ))}
+    <div className="flex flex-col flex-grow gap-5 pt-7">
+      {isEmpty ? (
+        <div className="flex-grow flex items-center justify-center text-defaultGrey">참여중인 채팅방이 없습니다</div>
+      ) : (
+        joinedChatrooms.map(chatroom => (
+          <JoinedChatroomItem
+            key={chatroom.chatroomId}
+            {...chatroom}
+            isEditMode={isEditMode}
+            isChecked={selectedChatrooms?.some(room => room.id === chatroom.chatroomId)}
+            onClick={() => onClick(chatroom.chatroomId, chatroom.isHost)}
+          />
+        ))
+      )}
+
       {!isEmpty && hasNextPage && <div ref={observerRef} className="h-4" />}
     </div>
   );

--- a/src/components/chatroom/chat/JoinedChatroomItem.tsx
+++ b/src/components/chatroom/chat/JoinedChatroomItem.tsx
@@ -1,16 +1,10 @@
 import CircleCheckBox from '@/components/checkbox/CircleCheckBox';
 import CrownIcon from '@/components/icon/CrownIcon';
 import ProfilePhoto from '@/components/photo/ProfilePhoto';
+import { JoinedChatroomType } from '@/types/chatTypes';
 import clsx from 'clsx';
 
-interface Props {
-  chatroomImage: string;
-  chatroomTitle: string;
-  currentMemberCount: number;
-  lastMessageTime: string;
-  lastMessage?: string;
-  isHost?: boolean;
-  unreadMessageCount?: number | string;
+interface Props extends JoinedChatroomType {
   isEditMode?: boolean;
 }
 
@@ -27,7 +21,7 @@ const JoinedChatroomItem = ({
   return (
     <div role="button" className="flex w-full items-center cursor-pointer">
       {isEditMode && <CircleCheckBox className="p-10 shrink-0" />}
-      <div className="flex flex-1 justify-between gap-3.5 p-5 min-w-0">
+      <div className="flex flex-1 justify-between gap-3.5 min-w-0">
         <div className="flex flex-1 items-center gap-3 min-w-0">
           <ProfilePhoto photo={chatroomImage} className="w-25 shrink-0" />
           <div className="flex flex-col gap-1.5 flex-1 min-w-0">
@@ -35,10 +29,10 @@ const JoinedChatroomItem = ({
               {isHost && <CrownIcon />}
               <div className="flex gap-1.5 items-end min-w-0">
                 <span className="truncate">{chatroomTitle}</span>
-                <span className="text-sm text-defaultGrey whitespace-nowrap">{currentMemberCount}</span>
+                <span className="text-defaultGrey whitespace-nowrap">{currentMemberCount}</span>
               </div>
             </p>
-            <p className="text-sm text-defaultGrey truncate min-w-0 whitespace-nowrap">{lastMessage}</p>
+            <p className="text-md text-defaultGrey truncate min-w-0 whitespace-nowrap">{lastMessage}</p>
           </div>
         </div>
         <div className="flex flex-col items-end justify-center gap-2.5 shrink-0">

--- a/src/components/chatroom/chat/JoinedChatroomItem.tsx
+++ b/src/components/chatroom/chat/JoinedChatroomItem.tsx
@@ -2,6 +2,7 @@ import CircleCheckBox from '@/components/checkbox/CircleCheckBox';
 import CrownIcon from '@/components/icon/CrownIcon';
 import ProfilePhoto from '@/components/photo/ProfilePhoto';
 import { JoinedChatroomType } from '@/types/chatTypes';
+import { formatDetailLastMessageTime } from '@/utils/chat/timeFormta';
 import clsx from 'clsx';
 
 interface Props extends JoinedChatroomType {
@@ -22,6 +23,7 @@ const JoinedChatroomItem = ({
   isChecked,
   onClick,
 }: Props) => {
+  const messageTimeFormat = formatDetailLastMessageTime(lastMessageTime);
   return (
     <div role="button" className="flex w-full items-center cursor-pointer" onClick={onClick}>
       {isEditMode && <CircleCheckBox className="p-7 shrink-0" isChecked={isChecked} />}
@@ -40,7 +42,7 @@ const JoinedChatroomItem = ({
           </div>
         </div>
         <div className="flex flex-col items-end justify-center gap-2.5 shrink-0">
-          <time className="w-fit text-sm whitespace-nowrap">{lastMessageTime}</time>
+          <time className="w-fit text-sm whitespace-nowrap">{messageTimeFormat}</time>
           <div
             className={clsx(
               'w-fit flex items-center justify-center min-h-8 aspect-square text-sm rounded-full text-white p-1.5',

--- a/src/components/chatroom/chat/JoinedChatroomItem.tsx
+++ b/src/components/chatroom/chat/JoinedChatroomItem.tsx
@@ -6,6 +6,8 @@ import clsx from 'clsx';
 
 interface Props extends JoinedChatroomType {
   isEditMode?: boolean;
+  isChecked?: boolean;
+  onClick?: () => void;
 }
 
 const JoinedChatroomItem = ({
@@ -17,13 +19,15 @@ const JoinedChatroomItem = ({
   isHost,
   unreadMessageCount,
   isEditMode,
+  isChecked,
+  onClick,
 }: Props) => {
   return (
-    <div role="button" className="flex w-full items-center cursor-pointer">
-      {isEditMode && <CircleCheckBox className="p-10 shrink-0" />}
+    <div role="button" className="flex w-full items-center cursor-pointer" onClick={onClick}>
+      {isEditMode && <CircleCheckBox className="p-7 shrink-0" isChecked={isChecked} />}
       <div className="flex flex-1 justify-between gap-3.5 min-w-0">
         <div className="flex flex-1 items-center gap-3 min-w-0">
-          <ProfilePhoto photo={chatroomImage} className="w-25 shrink-0" />
+          <ProfilePhoto photo={chatroomImage} className="w-25 shrink-0 cursor-pointer" />
           <div className="flex flex-col gap-1.5 flex-1 min-w-0">
             <p className="flex gap-2.5 items-center min-w-0">
               {isHost && <CrownIcon />}

--- a/src/components/chatroom/chat/PublicChatroomItem.tsx
+++ b/src/components/chatroom/chat/PublicChatroomItem.tsx
@@ -1,15 +1,9 @@
 import SubActionButton from '@/components/button/SubActionButton';
 import UserIcon from '@/components/icon/UserIcon';
 import ProfilePhoto from '@/components/photo/ProfilePhoto';
+import { PublicChatroomType } from '@/types/chatTypes';
 
-interface Props {
-  chatroomImage: string;
-  chatroomTitle: string;
-  description: string;
-  hashtags?: string[];
-  currentMemberCount: number;
-  maxMemberCount: number;
-  lastMessageTime: string;
+interface Props extends PublicChatroomType {
   isEditMode?: boolean;
 }
 
@@ -24,7 +18,7 @@ const PublicChatroomItem = ({
   isEditMode,
 }: Props) => {
   return (
-    <div className="flex items-center gap-7 w-full min-w-0 p-5 cursor-pointer">
+    <div className="flex items-center gap-7 w-full min-w-0 cursor-pointer">
       <ProfilePhoto photo={chatroomImage} className="w-32 shrink-0" />
       <div className="flex flex-col gap-2.5 flex-1 min-w-0">
         <p className="truncate">{chatroomTitle}</p>

--- a/src/components/chatroom/chat/PublicChatroomItem.tsx
+++ b/src/components/chatroom/chat/PublicChatroomItem.tsx
@@ -2,6 +2,7 @@ import SubActionButton from '@/components/button/SubActionButton';
 import UserIcon from '@/components/icon/UserIcon';
 import ProfilePhoto from '@/components/photo/ProfilePhoto';
 import { PublicChatroomType } from '@/types/chatTypes';
+import { formatPublicLastMessageTime } from '@/utils/chat/timeFormta';
 
 interface Props extends PublicChatroomType {
   isEditMode?: boolean;
@@ -17,6 +18,7 @@ const PublicChatroomItem = ({
   lastMessageTime,
   isEditMode,
 }: Props) => {
+  const messageTimeFormat = formatPublicLastMessageTime(lastMessageTime);
   return (
     <div className="flex items-center gap-7 w-full min-w-0 cursor-pointer">
       <ProfilePhoto photo={chatroomImage} className="w-32 shrink-0" />
@@ -32,7 +34,7 @@ const PublicChatroomItem = ({
             <span className="text-defaultGrey">
               {currentMemberCount}/{maxMemberCount}
             </span>{' '}
-            | <span>{lastMessageTime}</span>
+            {messageTimeFormat && <time>| {messageTimeFormat}</time>}
           </p>
         </div>
       </div>

--- a/src/components/header/ChatroomEditHeader.tsx
+++ b/src/components/header/ChatroomEditHeader.tsx
@@ -2,16 +2,18 @@ import DefaultHeader from '@/components/header/DefaultHeader';
 import LabelButton from '@/components/button/LabelButton';
 
 interface Props {
+  onLeftClick?: () => void;
+  onRightClick?: () => void;
   buttonLabel: string;
   disabled?: boolean;
 }
 
-const ChatroomEditHeader = ({ buttonLabel, disabled }: Props) => {
+const ChatroomEditHeader = ({ onLeftClick, onRightClick, buttonLabel, disabled }: Props) => {
   return (
     <DefaultHeader
-      leftButton={<LabelButton label="완료" />}
+      leftButton={<LabelButton label="완료" onClick={onLeftClick} />}
       label="편집"
-      rightButton={<LabelButton label={buttonLabel} disabled={disabled} />}
+      rightButton={<LabelButton label={buttonLabel} disabled={disabled} onClick={onRightClick} />}
     />
   );
 };

--- a/src/components/menu/DropdownMenuBase.tsx
+++ b/src/components/menu/DropdownMenuBase.tsx
@@ -7,10 +7,10 @@ interface Props {
 
 const DropdownMenuBase = ({ options }: Props) => {
   return (
-    <div className="w-[15rem] rounded-xl border border-strokeGray bg-white shadow opacity-75">
-      {options.map((option, i) => (
+    <div className="w-[15rem] rounded-xl border border-strokeGray bg-white shadow">
+      {options.map(option => (
         <button
-          key={i}
+          key={option.label}
           onClick={option.onClick}
           className={clsx('block w-full text-left p-4 text-md rounded-md cursor-pointer', {
             'text-sunsetRose': option.danger,

--- a/src/components/menu/GlobalChatroomDropDown.tsx
+++ b/src/components/menu/GlobalChatroomDropDown.tsx
@@ -2,6 +2,7 @@ import DropdownMenuBase from '@/components/menu/DropdownMenuBase';
 import { useMarkAllChatroomsAsRead } from '@/hooks/apis/chat/useMarkAllChatroomsAsRead';
 import { ChatroomViewModeValue } from '@/types/chatTypes';
 import { DropDownMenuOption } from '@/types/propsTypes';
+import { useNavigate } from 'react-router-dom';
 
 interface Props {
   viewMode: ChatroomViewModeValue;
@@ -10,9 +11,10 @@ interface Props {
 }
 
 const GlobalChatroomDropDown = ({ viewMode, closeMenu, openModal }: Props) => {
+  const navigate = useNavigate();
   const { mutate: allChatroomRead } = useMarkAllChatroomsAsRead(closeMenu);
   const joinedOptions: DropDownMenuOption[] = [
-    { label: '채팅방 편집' },
+    { label: '채팅방 편집', onClick: () => navigate('/chat/edit') },
     { label: '모두 읽음', onClick: allChatroomRead },
   ];
 

--- a/src/components/menu/GlobalChatroomDropDown.tsx
+++ b/src/components/menu/GlobalChatroomDropDown.tsx
@@ -1,8 +1,33 @@
 import DropdownMenuBase from '@/components/menu/DropdownMenuBase';
+import { useMarkAllChatroomsAsRead } from '@/hooks/apis/chat/useMarkAllChatroomsAsRead';
+import { ChatroomViewModeValue } from '@/types/chatTypes';
 import { DropDownMenuOption } from '@/types/propsTypes';
 
-const GlobalChatroomDropDown = () => {
-  const options: DropDownMenuOption[] = [{ label: '채팅방 편집' }, { label: '랭킹 기능' }, { label: '모두 읽음' }];
+interface Props {
+  viewMode: ChatroomViewModeValue;
+  closeMenu: () => void;
+  openModal: () => void;
+}
+
+const GlobalChatroomDropDown = ({ viewMode, closeMenu, openModal }: Props) => {
+  const { mutate: allChatroomRead } = useMarkAllChatroomsAsRead(closeMenu);
+  const joinedOptions: DropDownMenuOption[] = [
+    { label: '채팅방 편집' },
+    { label: '모두 읽음', onClick: allChatroomRead },
+  ];
+
+  const commonOptions: DropDownMenuOption[] = [
+    {
+      label: '랭킹 기능',
+      onClick: () => {
+        openModal();
+        closeMenu();
+      },
+    },
+  ];
+
+  const options = viewMode === 'joined' ? [...joinedOptions, ...commonOptions] : [...commonOptions];
+
   return <DropdownMenuBase options={options} />;
 };
 

--- a/src/components/modal/ModalDimmed.tsx
+++ b/src/components/modal/ModalDimmed.tsx
@@ -5,9 +5,7 @@ interface Props {
 
 const ModalDimmed = ({ children, onClose }: Props) => {
   return (
-    <div
-      className="w-full min-h-screen flex justify-center items-center bg-black/20 absolute inset-0 z-10"
-      onClick={onClose}>
+    <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/20" onClick={onClose}>
       {children}
     </div>
   );

--- a/src/components/modal/ModalDimmed.tsx
+++ b/src/components/modal/ModalDimmed.tsx
@@ -6,7 +6,7 @@ interface Props {
 const ModalDimmed = ({ children, onClose }: Props) => {
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/20" onClick={onClose}>
-      {children}
+      <div className="w-full flex justify-center max-w-[90%] sm:max-w-[500px]">{children}</div>
     </div>
   );
 };

--- a/src/components/tapbar/TapBar.tsx
+++ b/src/components/tapbar/TapBar.tsx
@@ -1,7 +1,7 @@
 import CalenderIcon from '@/components/icon/CalenderIcon';
 import MonthWeekIcon from '@/components/icon/MonthWeekIcon';
 import ChartIcon from '@/components/icon/ChartIcon';
-// import TalkIcon from '@/components/icon/TalkIcon';
+import TalkIcon from '@/components/icon/TalkIcon';
 import SettingIcon from '@/components/icon/SettingIcon';
 import { TapBarType } from '@/types/types';
 import { useState } from 'react';
@@ -33,7 +33,7 @@ const TapBar = ({ page }: Props) => {
       <TapItem currentTap={currentTap} targetTap="main" onClick={handleTapClick} icon={<CalenderIcon />} />
       <TapItem currentTap={currentTap} targetTap="month-week" onClick={handleTapClick} icon={<MonthWeekIcon />} />
       <TapItem currentTap={currentTap} targetTap="chart" onClick={handleTapClick} icon={<ChartIcon />} />
-      {/* <TapItem currentTap={currentTap} targetTap="talk" onClick={handleTapClick} icon={<TalkIcon />} /> */}
+      <TapItem currentTap={currentTap} targetTap="chat" onClick={handleTapClick} icon={<TalkIcon />} />
       <TapItem currentTap={currentTap} targetTap="setting" onClick={handleTapClick} icon={<SettingIcon />} />
     </div>
   );

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,1 @@
+export const joinedChatroomsQueryKey = ['joinedChatrooms'];

--- a/src/hooks/apis/chat/useAllChatroomsInfiniteQuery.ts
+++ b/src/hooks/apis/chat/useAllChatroomsInfiniteQuery.ts
@@ -1,0 +1,26 @@
+import { getAllChatrooms } from '@/api/services/chatService';
+import { AllChatroomsRes, ChatroomSortOptionValue, ChatroomSortParam } from '@/types/chatTypes';
+import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
+
+const useAllChatroomsInfiniteQuery = (option: ChatroomSortOptionValue) => {
+  const mapSortOptionToParam = (option: ChatroomSortOptionValue): ChatroomSortParam => {
+    const map = {
+      popularity: 'POPULARITY',
+      createdAt: 'CREATED_AT',
+      likes: 'LIKE',
+    } as const;
+
+    return map[option];
+  };
+  const sortBy = mapSortOptionToParam(option);
+
+  return useInfiniteQuery<AllChatroomsRes, Error, InfiniteData<AllChatroomsRes>, string[], string | null>({
+    queryKey: ['allChatrooms', sortBy],
+    queryFn: async ({ pageParam = null }) => await getAllChatrooms(sortBy, pageParam),
+    initialPageParam: null,
+    getNextPageParam: lastPage => (lastPage.hasNext ? lastPage.nextCursor : undefined),
+    placeholderData: prevData => prevData,
+  });
+};
+
+export default useAllChatroomsInfiniteQuery;

--- a/src/hooks/apis/chat/useJoinedChatroomsInfiniteQuery.ts
+++ b/src/hooks/apis/chat/useJoinedChatroomsInfiniteQuery.ts
@@ -1,0 +1,15 @@
+import { getJoinedChatrooms } from '@/api/services/chatService';
+import { JoinedChatroomsRes } from '@/types/chatTypes';
+import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
+
+const useJoinedChatroomsInfiniteQuery = () => {
+  return useInfiniteQuery<JoinedChatroomsRes, Error, InfiniteData<JoinedChatroomsRes>, string[], string | null>({
+    queryKey: ['joinedChatrooms'],
+    queryFn: async ({ pageParam = null }) => await getJoinedChatrooms(pageParam),
+    initialPageParam: null,
+    getNextPageParam: lastPage => (lastPage.hasNext ? lastPage.nextCursor : undefined),
+    placeholderData: prevData => prevData,
+  });
+};
+
+export default useJoinedChatroomsInfiniteQuery;

--- a/src/hooks/apis/chat/useJoinedChatroomsInfiniteQuery.ts
+++ b/src/hooks/apis/chat/useJoinedChatroomsInfiniteQuery.ts
@@ -1,14 +1,16 @@
 import { getJoinedChatrooms } from '@/api/services/chatService';
+import { joinedChatroomsQueryKey } from '@/constants/queryKeys';
 import { JoinedChatroomsRes } from '@/types/chatTypes';
 import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
 
 const useJoinedChatroomsInfiniteQuery = () => {
   return useInfiniteQuery<JoinedChatroomsRes, Error, InfiniteData<JoinedChatroomsRes>, string[], string | null>({
-    queryKey: ['joinedChatrooms'],
+    queryKey: joinedChatroomsQueryKey,
     queryFn: async ({ pageParam = null }) => await getJoinedChatrooms(pageParam),
     initialPageParam: null,
     getNextPageParam: lastPage => (lastPage.hasNext ? lastPage.nextCursor : undefined),
     placeholderData: prevData => prevData,
+    staleTime: Infinity,
   });
 };
 

--- a/src/hooks/apis/chat/useLeaveMultipleChatrooms.ts
+++ b/src/hooks/apis/chat/useLeaveMultipleChatrooms.ts
@@ -1,0 +1,28 @@
+import { leaveMultipleChatrooms } from '@/api/services/chatService';
+import { joinedChatroomsQueryKey } from '@/constants/queryKeys';
+import { JoinedChatroomsRes } from '@/types/chatTypes';
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+
+const useLeaveMultipleChatrooms = (clearSelectedStatus: () => void, closeModal: () => void) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: leaveMultipleChatrooms,
+    onSuccess: data => {
+      queryClient.setQueryData<InfiniteData<JoinedChatroomsRes>>(joinedChatroomsQueryKey, prev => {
+        if (!prev || !data) return prev;
+        return {
+          ...prev,
+          pages: prev.pages.map(page => ({
+            ...page,
+            chatrooms: page.chatrooms.filter(room => !data.deletedChatroomIds.includes(room.chatroomId)),
+          })),
+        };
+      });
+      closeModal();
+      clearSelectedStatus();
+    },
+  });
+};
+
+export default useLeaveMultipleChatrooms;

--- a/src/hooks/apis/chat/useMarkAllChatroomsAsRead.ts
+++ b/src/hooks/apis/chat/useMarkAllChatroomsAsRead.ts
@@ -1,0 +1,27 @@
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+import { markAllChatroomsAsRead } from '@/api/services/chatService';
+import { JoinedChatroomsRes } from '@/types/chatTypes';
+
+export const useMarkAllChatroomsAsRead = (closeMenu: () => void) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: markAllChatroomsAsRead,
+    onSuccess: () => {
+      queryClient.setQueryData<InfiniteData<JoinedChatroomsRes>>(['joinedChatrooms'], prev => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          pages: prev.pages.map(page => ({
+            ...page,
+            chatrooms: page.chatrooms.map(room => ({
+              ...room,
+              unreadMessageCount: 0,
+            })),
+          })),
+        };
+      });
+      closeMenu();
+    },
+  });
+};

--- a/src/hooks/apis/chat/useMarkAllChatroomsAsRead.ts
+++ b/src/hooks/apis/chat/useMarkAllChatroomsAsRead.ts
@@ -1,6 +1,7 @@
 import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
 import { markAllChatroomsAsRead } from '@/api/services/chatService';
 import { JoinedChatroomsRes } from '@/types/chatTypes';
+import { joinedChatroomsQueryKey } from '@/constants/queryKeys';
 
 export const useMarkAllChatroomsAsRead = (closeMenu: () => void) => {
   const queryClient = useQueryClient();
@@ -8,7 +9,7 @@ export const useMarkAllChatroomsAsRead = (closeMenu: () => void) => {
   return useMutation({
     mutationFn: markAllChatroomsAsRead,
     onSuccess: () => {
-      queryClient.setQueryData<InfiniteData<JoinedChatroomsRes>>(['joinedChatrooms'], prev => {
+      queryClient.setQueryData<InfiniteData<JoinedChatroomsRes>>(joinedChatroomsQueryKey, prev => {
         if (!prev) return prev;
         return {
           ...prev,

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+type UseClickOutsideProps = {
+  refs: React.RefObject<HTMLElement>[];
+  onClickOutside: () => void;
+};
+
+const useClickOutside = ({ refs, onClickOutside }: UseClickOutsideProps) => {
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      const clickedInside = refs.some(ref => ref.current?.contains(target));
+      if (!clickedInside) onClickOutside();
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+    };
+  }, [refs, onClickOutside]);
+};
+
+export default useClickOutside;

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -7,7 +7,8 @@ import { totalHandlers } from '@/mocks/handler/totalHandlers';
 import { transactionHandlers } from '@/mocks/handler/transactionHandlers';
 import { categoryHandlers } from '@/mocks/handler/categoryHandlers';
 import { chartHandlers } from '@/mocks/handler/chartHandlers';
-import { categoryLogsHandler } from './handler/categoryLogsHandler';
+import { categoryLogsHandler } from '@/mocks/handler/categoryLogsHandler';
+import { chatHandlers } from '@/mocks/handler/chatHandlers';
 
 export const worker = setupWorker(
   ...loginHandlers,
@@ -19,4 +20,5 @@ export const worker = setupWorker(
   ...categoryHandlers,
   ...chartHandlers,
   categoryLogsHandler,
+  ...chatHandlers,
 );

--- a/src/mocks/handler/chatHandlers.ts
+++ b/src/mocks/handler/chatHandlers.ts
@@ -1,0 +1,67 @@
+import { AllChatroomsRes, ChatroomSortParam, JoinedChatroomType } from '@/types/chatTypes';
+import { http, HttpResponse } from 'msw';
+import Profile from '/image/default-profile-image.webp';
+
+export const chatHandlers = [
+  http.get('/chatrooms', ({ request }) => {
+    const url = new URL(request.url);
+    const sortBy = url.searchParams.get('sortBy') as ChatroomSortParam;
+    const cursor = url.searchParams.get('cursor');
+    const baseId = cursor ? parseInt(cursor, 10) + 1 : 1;
+
+    const chatrooms = Array.from({ length: 10 }).map((_, i) => ({
+      chatroomId: baseId + i,
+      chatroomImage: Profile,
+      chatroomTitle: `채팅방 ${baseId + i}`,
+      description: `정렬 기준: ${sortBy}`,
+      hashtags: ['#일상', '#스터디'],
+      currentMemberCount: Math.floor(Math.random() * 10) + 1,
+      maxMemberCount: 20,
+      lastMessageTime: new Date().toISOString(),
+    }));
+
+    const isLastPage = baseId >= 30;
+
+    const response: AllChatroomsRes = {
+      chatrooms,
+      hasNext: !isLastPage,
+      nextCursor: isLastPage ? '' : String(baseId + 9),
+    };
+
+    return HttpResponse.json({ data: response }, { status: 200 });
+  }),
+
+  http.get('/users/me/chatrooms', ({ request }) => {
+    const url = new URL(request.url);
+    const cursorParam = url.searchParams.get('cursor');
+    const cursor = cursorParam ? parseInt(cursorParam, 10) : null;
+    const baseId = cursor ? cursor + 1 : 1;
+
+    const chatrooms: JoinedChatroomType[] = Array.from({ length: 10 }).map((_, i) => {
+      const id = baseId + i;
+      return {
+        chatroomId: id,
+        chatroomImage: Profile,
+        chatroomTitle: `참여중인 채팅방 ${id}`,
+        currentMemberCount: Math.floor(Math.random() * 10) + 1,
+        lastMessageTime: new Date(Date.now() - i * 1000 * 60).toISOString(),
+        lastMessage: `마지막 메시지 ${id}`,
+        isHost: id % 3 === 0,
+        unreadMessageCount: id % 5 === 0 ? '99+' : Math.floor(Math.random() * 10),
+      };
+    });
+
+    const isLastPage = baseId >= 30;
+
+    return HttpResponse.json(
+      {
+        data: {
+          chatrooms,
+          hasNext: !isLastPage,
+          nextCursor: !isLastPage ? String(baseId + 9) : undefined,
+        },
+      },
+      { status: 200 },
+    );
+  }),
+];

--- a/src/mocks/handler/chatHandlers.ts
+++ b/src/mocks/handler/chatHandlers.ts
@@ -2,6 +2,7 @@ import { AllChatroomsRes, ChatroomSortParam, JoinedChatroomType, leaveMultipleCh
 import { delay, http, HttpResponse } from 'msw';
 import Profile from '/image/default-profile-image.webp';
 import { endpoints } from '@/api/endpoints';
+import { getRandomTime } from '../utils/getRandomTime';
 
 export const chatHandlers = [
   http.get('/chatrooms', ({ request }) => {
@@ -18,7 +19,7 @@ export const chatHandlers = [
       hashtags: ['#일상', '#스터디'],
       currentMemberCount: Math.floor(Math.random() * 10) + 1,
       maxMemberCount: 20,
-      lastMessageTime: new Date().toISOString(),
+      lastMessageTime: getRandomTime(),
     }));
 
     const isLastPage = baseId >= 30;
@@ -45,7 +46,7 @@ export const chatHandlers = [
         chatroomImage: Profile,
         chatroomTitle: `참여중인 채팅방 ${id}`,
         currentMemberCount: Math.floor(Math.random() * 10) + 1,
-        lastMessageTime: new Date(Date.now() - i * 1000 * 60).toISOString(),
+        lastMessageTime: getRandomTime(),
         lastMessage: `마지막 메시지 ${id}`,
         isHost: id % 3 === 0,
         unreadMessageCount: id % 5 === 0 ? '99+' : Math.floor(Math.random() * 10),

--- a/src/mocks/handler/chatHandlers.ts
+++ b/src/mocks/handler/chatHandlers.ts
@@ -1,5 +1,5 @@
-import { AllChatroomsRes, ChatroomSortParam, JoinedChatroomType } from '@/types/chatTypes';
-import { http, HttpResponse } from 'msw';
+import { AllChatroomsRes, ChatroomSortParam, JoinedChatroomType, leaveMultipleChatroomsReq } from '@/types/chatTypes';
+import { delay, http, HttpResponse } from 'msw';
 import Profile from '/image/default-profile-image.webp';
 import { endpoints } from '@/api/endpoints';
 
@@ -67,5 +67,11 @@ export const chatHandlers = [
   }),
   http.patch(endpoints.chat.markAllAsRead, () => {
     return HttpResponse.json({ status: 200, message: '메세지를 모두 읽음 처리했습니다.' }, { status: 200 });
+  }),
+  http.delete(endpoints.chat.leaveMultipleChatrooms, async ({ request }) => {
+    await delay(500);
+    const { chatroomsToLeave } = (await request.json()) as leaveMultipleChatroomsReq;
+
+    return HttpResponse.json({ data: { deletedChatroomIds: chatroomsToLeave } }, { status: 200 });
   }),
 ];

--- a/src/mocks/handler/chatHandlers.ts
+++ b/src/mocks/handler/chatHandlers.ts
@@ -1,6 +1,7 @@
 import { AllChatroomsRes, ChatroomSortParam, JoinedChatroomType } from '@/types/chatTypes';
 import { http, HttpResponse } from 'msw';
 import Profile from '/image/default-profile-image.webp';
+import { endpoints } from '@/api/endpoints';
 
 export const chatHandlers = [
   http.get('/chatrooms', ({ request }) => {
@@ -63,5 +64,8 @@ export const chatHandlers = [
       },
       { status: 200 },
     );
+  }),
+  http.patch(endpoints.chat.markAllAsRead, () => {
+    return HttpResponse.json({ status: 200, message: '메세지를 모두 읽음 처리했습니다.' }, { status: 200 });
   }),
 ];

--- a/src/mocks/utils/getRandomTime.ts
+++ b/src/mocks/utils/getRandomTime.ts
@@ -1,0 +1,5 @@
+export const getRandomTime = () => {
+  const maxMinutesAgo = 43200; // 30일 = 43200분
+  const randomMinutes = Math.floor(Math.random() * (maxMinutesAgo + 1));
+  return new Date(Date.now() - randomMinutes * 60 * 1000).toISOString();
+};

--- a/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
+++ b/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
@@ -9,7 +9,7 @@ import TapBar from '@/components/tapbar/TapBar';
 import { ChatroomSortOptionValue, ChatroomViewModeValue } from '@/types/chatTypes';
 import { useEffect, useRef, useState } from 'react';
 import AllChatroomsList from '@/pages/ChatLobbyPage/components/AllChatroomsList';
-import JoinedChatroomList from '@/pages/ChatLobbyPage/components/JoinedChatroomList';
+import JoinedChatroomList from '@/components/chatroom/JoinedChatroomList';
 import GlobalChatroomDropDown from '@/components/menu/GlobalChatroomDropDown';
 import useModal from '@/hooks/useModal';
 import RankingInfoModal from '@/components/chatroom/modal/RankingInfoModal';
@@ -40,7 +40,7 @@ const ChatLobbyPage = () => {
   return (
     <div className="w-full min-h-screen flex flex-col relative">
       <DefaultHeader label="지갑 봉합소" rightButton={<PlusButton />} />
-      <div className="flex-grow p-5">
+      <div className="flex flex-col flex-grow p-5">
         <div className="flex justify-between relative">
           <ChatroomViewModeToggle viewMode={viewMode} onClick={(value: ChatroomViewModeValue) => setViewMode(value)} />
           <div className="flex gap-3">

--- a/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
+++ b/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
@@ -1,0 +1,44 @@
+import ChatroomSortOptions from '@/components/button/ChatroomSortOptions';
+import ChatroomSearchButton from '@/components/button/icon/ChatroomSearchButton';
+import ChatroomSettingsButton from '@/components/button/icon/ChatroomSettingsButton';
+import MyHostedChatroomsButton from '@/components/button/icon/MyHostedChatroomsButton';
+import PlusButton from '@/components/button/icon/PlusButton';
+import ChatroomViewModeToggle from '@/components/button/toggle/ChatroomViewModeToggle';
+import DefaultHeader from '@/components/header/DefaultHeader';
+import TapBar from '@/components/tapbar/TapBar';
+import { ChatroomSortOptionValue, ChatroomViewModeValue } from '@/types/chatTypes';
+import { useState } from 'react';
+import AllChatroomsList from './components/AllChatroomsList';
+import JoinedChatroomList from './components/JoinedChatroomList';
+
+const ChatLobbyPage = () => {
+  const [viewMode, setViewMode] = useState<ChatroomViewModeValue>('all');
+  const [sortOption, setSortOption] = useState<ChatroomSortOptionValue>('popularity');
+
+  return (
+    <div className="w-full min-h-screen flex flex-col relative">
+      <DefaultHeader label="지갑 봉합소" rightButton={<PlusButton />} />
+      <div className="flex-grow p-5">
+        <div className="flex justify-between">
+          <ChatroomViewModeToggle viewMode={viewMode} onClick={(value: ChatroomViewModeValue) => setViewMode(value)} />
+          <div className="flex gap-3">
+            <ChatroomSearchButton />
+            <MyHostedChatroomsButton />
+            <ChatroomSettingsButton />
+          </div>
+        </div>
+        {viewMode === 'all' && (
+          <ChatroomSortOptions
+            sortOption={sortOption}
+            onClick={(value: ChatroomSortOptionValue) => setSortOption(value)}
+          />
+        )}
+
+        {viewMode === 'all' ? <AllChatroomsList sortOption={sortOption} /> : <JoinedChatroomList />}
+      </div>
+      <TapBar page="chat" />
+    </div>
+  );
+};
+
+export default ChatLobbyPage;

--- a/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
+++ b/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
@@ -7,7 +7,7 @@ import ChatroomViewModeToggle from '@/components/button/toggle/ChatroomViewModeT
 import DefaultHeader from '@/components/header/DefaultHeader';
 import TapBar from '@/components/tapbar/TapBar';
 import { ChatroomSortOptionValue, ChatroomViewModeValue } from '@/types/chatTypes';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import AllChatroomsList from '@/pages/ChatLobbyPage/components/AllChatroomsList';
 import JoinedChatroomList from '@/pages/ChatLobbyPage/components/JoinedChatroomList';
 import GlobalChatroomDropDown from '@/components/menu/GlobalChatroomDropDown';
@@ -15,6 +15,7 @@ import useModal from '@/hooks/useModal';
 import RankingInfoModal from '@/components/chatroom/modal/RankingInfoModal';
 import ModalDimmed from '@/components/modal/ModalDimmed';
 import useClickOutside from '@/hooks/useClickOutside';
+import { useLocation } from 'react-router-dom';
 
 const ChatLobbyPage = () => {
   const [viewMode, setViewMode] = useState<ChatroomViewModeValue>('all');
@@ -23,11 +24,18 @@ const ChatLobbyPage = () => {
   const { isOpen, openModal, closeModal } = useModal();
   const dropdownRef = useRef<HTMLDivElement>(null);
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
-
+  const location = useLocation();
+  const state = location.state as { viewMode?: ChatroomViewModeValue };
   useClickOutside({
     refs: [dropdownRef, settingsButtonRef],
     onClickOutside: () => setIsMenuOpen(false),
   });
+
+  useEffect(() => {
+    if (state?.viewMode) {
+      setViewMode(state.viewMode);
+    }
+  }, [state?.viewMode]);
 
   return (
     <div className="w-full min-h-screen flex flex-col relative">
@@ -63,7 +71,7 @@ const ChatLobbyPage = () => {
             <AllChatroomsList sortOption={sortOption} />
           </>
         ) : (
-          <JoinedChatroomList />
+          <JoinedChatroomList onClick={() => {}} />
         )}
       </div>
       {isOpen && (

--- a/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
+++ b/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
@@ -7,35 +7,70 @@ import ChatroomViewModeToggle from '@/components/button/toggle/ChatroomViewModeT
 import DefaultHeader from '@/components/header/DefaultHeader';
 import TapBar from '@/components/tapbar/TapBar';
 import { ChatroomSortOptionValue, ChatroomViewModeValue } from '@/types/chatTypes';
-import { useState } from 'react';
-import AllChatroomsList from './components/AllChatroomsList';
-import JoinedChatroomList from './components/JoinedChatroomList';
+import { useRef, useState } from 'react';
+import AllChatroomsList from '@/pages/ChatLobbyPage/components/AllChatroomsList';
+import JoinedChatroomList from '@/pages/ChatLobbyPage/components/JoinedChatroomList';
+import GlobalChatroomDropDown from '@/components/menu/GlobalChatroomDropDown';
+import useModal from '@/hooks/useModal';
+import RankingInfoModal from '@/components/chatroom/modal/RankingInfoModal';
+import ModalDimmed from '@/components/modal/ModalDimmed';
+import useClickOutside from '@/hooks/useClickOutside';
 
 const ChatLobbyPage = () => {
   const [viewMode, setViewMode] = useState<ChatroomViewModeValue>('all');
   const [sortOption, setSortOption] = useState<ChatroomSortOptionValue>('popularity');
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+  const { isOpen, openModal, closeModal } = useModal();
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const settingsButtonRef = useRef<HTMLButtonElement>(null);
+
+  useClickOutside({
+    refs: [dropdownRef, settingsButtonRef],
+    onClickOutside: () => setIsMenuOpen(false),
+  });
 
   return (
     <div className="w-full min-h-screen flex flex-col relative">
       <DefaultHeader label="지갑 봉합소" rightButton={<PlusButton />} />
       <div className="flex-grow p-5">
-        <div className="flex justify-between">
+        <div className="flex justify-between relative">
           <ChatroomViewModeToggle viewMode={viewMode} onClick={(value: ChatroomViewModeValue) => setViewMode(value)} />
           <div className="flex gap-3">
             <ChatroomSearchButton />
             <MyHostedChatroomsButton />
-            <ChatroomSettingsButton />
+            <ChatroomSettingsButton
+              isMenuOpen={isMenuOpen}
+              onClick={() => setIsMenuOpen(prev => !prev)}
+              ref={settingsButtonRef}
+            />
           </div>
+          {isMenuOpen && (
+            <div className="absolute right-0 top-15" ref={dropdownRef}>
+              <GlobalChatroomDropDown
+                viewMode={viewMode}
+                closeMenu={() => setIsMenuOpen(false)}
+                openModal={openModal}
+              />
+            </div>
+          )}
         </div>
-        {viewMode === 'all' && (
-          <ChatroomSortOptions
-            sortOption={sortOption}
-            onClick={(value: ChatroomSortOptionValue) => setSortOption(value)}
-          />
+        {viewMode === 'all' ? (
+          <>
+            <ChatroomSortOptions
+              sortOption={sortOption}
+              onClick={(value: ChatroomSortOptionValue) => setSortOption(value)}
+            />
+            <AllChatroomsList sortOption={sortOption} />
+          </>
+        ) : (
+          <JoinedChatroomList />
         )}
-
-        {viewMode === 'all' ? <AllChatroomsList sortOption={sortOption} /> : <JoinedChatroomList />}
       </div>
+      {isOpen && (
+        <ModalDimmed onClose={closeModal}>
+          <RankingInfoModal closeModal={closeModal} />
+        </ModalDimmed>
+      )}
       <TapBar page="chat" />
     </div>
   );

--- a/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
+++ b/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
@@ -26,10 +26,16 @@ const ChatLobbyPage = () => {
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
   const location = useLocation();
   const state = location.state as { viewMode?: ChatroomViewModeValue };
+  const scrollPositions = useRef<{ all: number; joined: number }>({ all: 0, joined: 0 });
   useClickOutside({
     refs: [dropdownRef, settingsButtonRef],
     onClickOutside: () => setIsMenuOpen(false),
   });
+
+  const handleViewModeChange = (next: ChatroomViewModeValue) => {
+    scrollPositions.current[viewMode] = window.scrollY;
+    setViewMode(next);
+  };
 
   useEffect(() => {
     if (state?.viewMode) {
@@ -37,42 +43,55 @@ const ChatLobbyPage = () => {
     }
   }, [state?.viewMode]);
 
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      window.scrollTo(0, scrollPositions.current[viewMode]);
+    });
+  }, [viewMode]);
+
   return (
     <div className="w-full min-h-screen flex flex-col relative">
       <DefaultHeader label="지갑 봉합소" rightButton={<PlusButton />} />
-      <div className="flex flex-col flex-grow p-5">
-        <div className="flex justify-between relative">
-          <ChatroomViewModeToggle viewMode={viewMode} onClick={(value: ChatroomViewModeValue) => setViewMode(value)} />
-          <div className="flex gap-3">
-            <ChatroomSearchButton />
-            <MyHostedChatroomsButton />
-            <ChatroomSettingsButton
-              isMenuOpen={isMenuOpen}
-              onClick={() => setIsMenuOpen(prev => !prev)}
-              ref={settingsButtonRef}
+      <div className="flex flex-col flex-grow ">
+        <div className="sticky top-18 p-5 bg-white z-10">
+          <div className=" flex justify-between relative">
+            <ChatroomViewModeToggle
+              viewMode={viewMode}
+              onClick={(nextMode: ChatroomViewModeValue) => handleViewModeChange(nextMode)}
             />
-          </div>
-          {isMenuOpen && (
-            <div className="absolute right-0 top-15" ref={dropdownRef}>
-              <GlobalChatroomDropDown
-                viewMode={viewMode}
-                closeMenu={() => setIsMenuOpen(false)}
-                openModal={openModal}
+            <div className="flex gap-3">
+              <ChatroomSearchButton />
+              <MyHostedChatroomsButton />
+              <ChatroomSettingsButton
+                isMenuOpen={isMenuOpen}
+                onClick={() => setIsMenuOpen(prev => !prev)}
+                ref={settingsButtonRef}
               />
             </div>
+            {isMenuOpen && (
+              <div className="absolute right-0 top-15" ref={dropdownRef}>
+                <GlobalChatroomDropDown
+                  viewMode={viewMode}
+                  closeMenu={() => setIsMenuOpen(false)}
+                  openModal={openModal}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-col flex-grow overflow-y-auto">
+          {viewMode === 'all' ? (
+            <>
+              <ChatroomSortOptions
+                sortOption={sortOption}
+                onClick={(value: ChatroomSortOptionValue) => setSortOption(value)}
+              />
+              <AllChatroomsList sortOption={sortOption} />
+            </>
+          ) : (
+            <JoinedChatroomList onClick={() => {}} />
           )}
         </div>
-        {viewMode === 'all' ? (
-          <>
-            <ChatroomSortOptions
-              sortOption={sortOption}
-              onClick={(value: ChatroomSortOptionValue) => setSortOption(value)}
-            />
-            <AllChatroomsList sortOption={sortOption} />
-          </>
-        ) : (
-          <JoinedChatroomList onClick={() => {}} />
-        )}
       </div>
       {isOpen && (
         <ModalDimmed onClose={closeModal}>

--- a/src/pages/ChatLobbyPage/components/AllChatroomsList.tsx
+++ b/src/pages/ChatLobbyPage/components/AllChatroomsList.tsx
@@ -19,9 +19,12 @@ const AllChatroomsList = ({ sortOption }: Props) => {
 
   return (
     <div className="flex-grow flex flex-col gap-2.5 pt-3.5">
-      {allChatrooms.map(chatroom => (
-        <PublicChatroomItem key={chatroom.chatroomId} {...chatroom} />
-      ))}
+      {isEmpty ? (
+        <div className="flex-grow flex items-center justify-center text-defaultGrey">채팅방이 없습니다</div>
+      ) : (
+        allChatrooms.map(chatroom => <PublicChatroomItem key={chatroom.chatroomId} {...chatroom} />)
+      )}
+
       {!isEmpty && hasNextPage && <div ref={observerRef} className="h-4" />}
     </div>
   );

--- a/src/pages/ChatLobbyPage/components/AllChatroomsList.tsx
+++ b/src/pages/ChatLobbyPage/components/AllChatroomsList.tsx
@@ -1,0 +1,30 @@
+import { ChatroomSortOptionValue } from '@/types/chatTypes';
+import PublicChatroomItem from '@/components/chatroom/chat/PublicChatroomItem';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import useAllChatroomsInfiniteQuery from '@/hooks/apis/chat/useAllChatroomsInfiniteQuery';
+import { useRef } from 'react';
+
+interface Props {
+  sortOption: ChatroomSortOptionValue;
+}
+
+const AllChatroomsList = ({ sortOption }: Props) => {
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useAllChatroomsInfiniteQuery(sortOption);
+
+  const observerRef = useRef<HTMLDivElement | null>(null);
+  const allChatrooms = data?.pages?.flatMap(page => page.chatrooms) || [];
+  const isEmpty = allChatrooms?.length === 0;
+
+  useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
+
+  return (
+    <div className="flex-grow flex flex-col gap-2.5 pt-5">
+      {allChatrooms.map(chatroom => (
+        <PublicChatroomItem key={chatroom.chatroomId} {...chatroom} />
+      ))}
+      {!isEmpty && hasNextPage && <div ref={observerRef} className="h-4" />}
+    </div>
+  );
+};
+
+export default AllChatroomsList;

--- a/src/pages/ChatLobbyPage/components/AllChatroomsList.tsx
+++ b/src/pages/ChatLobbyPage/components/AllChatroomsList.tsx
@@ -18,7 +18,7 @@ const AllChatroomsList = ({ sortOption }: Props) => {
   useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
 
   return (
-    <div className="flex-grow flex flex-col gap-2.5 pt-3.5">
+    <div className="flex-grow flex flex-col gap-2.5 p-5">
       {isEmpty ? (
         <div className="flex-grow flex items-center justify-center text-defaultGrey">채팅방이 없습니다</div>
       ) : (

--- a/src/pages/ChatLobbyPage/components/AllChatroomsList.tsx
+++ b/src/pages/ChatLobbyPage/components/AllChatroomsList.tsx
@@ -18,7 +18,7 @@ const AllChatroomsList = ({ sortOption }: Props) => {
   useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
 
   return (
-    <div className="flex-grow flex flex-col gap-2.5 pt-5">
+    <div className="flex-grow flex flex-col gap-2.5 pt-3.5">
       {allChatrooms.map(chatroom => (
         <PublicChatroomItem key={chatroom.chatroomId} {...chatroom} />
       ))}

--- a/src/pages/ChatLobbyPage/components/JoinedChatroomList.tsx
+++ b/src/pages/ChatLobbyPage/components/JoinedChatroomList.tsx
@@ -1,0 +1,25 @@
+import JoinedChatroomItem from '@/components/chatroom/chat/JoinedChatroomItem';
+import useJoinedChatroomsInfiniteQuery from '@/hooks/apis/chat/useJoinedChatroomsInfiniteQuery';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import { useRef } from 'react';
+
+const JoinedChatroomList = () => {
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useJoinedChatroomsInfiniteQuery();
+
+  const observerRef = useRef<HTMLDivElement | null>(null);
+  const joinedChatrooms = data?.pages?.flatMap(page => page.chatrooms) || [];
+  const isEmpty = joinedChatrooms?.length === 0;
+
+  useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
+
+  return (
+    <div className="flex-grow flex flex-col gap-5 pt-7">
+      {joinedChatrooms.map(chatroom => (
+        <JoinedChatroomItem {...chatroom} />
+      ))}
+      {!isEmpty && hasNextPage && <div ref={observerRef} className="h-4" />}
+    </div>
+  );
+};
+
+export default JoinedChatroomList;

--- a/src/pages/ChatLobbyPage/components/JoinedChatroomList.tsx
+++ b/src/pages/ChatLobbyPage/components/JoinedChatroomList.tsx
@@ -3,7 +3,13 @@ import useJoinedChatroomsInfiniteQuery from '@/hooks/apis/chat/useJoinedChatroom
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import { useRef } from 'react';
 
-const JoinedChatroomList = () => {
+interface Props {
+  isEditMode?: boolean;
+  selectedChatrooms?: { id: number; isHost: boolean }[];
+  onClick: (id: number, isHost: boolean) => void;
+}
+
+const JoinedChatroomList = ({ isEditMode, selectedChatrooms, onClick }: Props) => {
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useJoinedChatroomsInfiniteQuery();
 
   const observerRef = useRef<HTMLDivElement | null>(null);
@@ -15,7 +21,13 @@ const JoinedChatroomList = () => {
   return (
     <div className="flex-grow flex flex-col gap-5 pt-7">
       {joinedChatrooms.map(chatroom => (
-        <JoinedChatroomItem key={chatroom.chatroomId} {...chatroom} />
+        <JoinedChatroomItem
+          key={chatroom.chatroomId}
+          {...chatroom}
+          isEditMode={isEditMode}
+          isChecked={selectedChatrooms?.some(room => room.id === chatroom.chatroomId)}
+          onClick={() => onClick(chatroom.chatroomId, chatroom.isHost)}
+        />
       ))}
       {!isEmpty && hasNextPage && <div ref={observerRef} className="h-4" />}
     </div>

--- a/src/pages/ChatLobbyPage/components/JoinedChatroomList.tsx
+++ b/src/pages/ChatLobbyPage/components/JoinedChatroomList.tsx
@@ -15,7 +15,7 @@ const JoinedChatroomList = () => {
   return (
     <div className="flex-grow flex flex-col gap-5 pt-7">
       {joinedChatrooms.map(chatroom => (
-        <JoinedChatroomItem {...chatroom} />
+        <JoinedChatroomItem key={chatroom.chatroomId} {...chatroom} />
       ))}
       {!isEmpty && hasNextPage && <div ref={observerRef} className="h-4" />}
     </div>

--- a/src/pages/JoinedChatroomsEditPage/JoinedChatroomsEditPage.tsx
+++ b/src/pages/JoinedChatroomsEditPage/JoinedChatroomsEditPage.tsx
@@ -1,0 +1,71 @@
+import ChatActionButton from '@/components/button/ChatActionButton';
+import ChatroomEditHeader from '@/components/header/ChatroomEditHeader';
+import { useNavigate } from 'react-router-dom';
+import JoinedChatroomList from '../ChatLobbyPage/components/JoinedChatroomList';
+import { useState } from 'react';
+import useLeaveMultipleChatrooms from '@/hooks/apis/chat/useLeaveMultipleChatrooms';
+import useModal from '@/hooks/useModal';
+import ConsentModal from '@/components/chatroom/modal/ConsentModal';
+import { HOST_LEAVE_CHATROOM_NOTICE, MEMBER_LEAVE_CHATROOM_NOTICE } from '@/constants/modal';
+import ModalDimmed from '@/components/modal/ModalDimmed';
+
+const JoinedChatroomsEditPage = () => {
+  const navigate = useNavigate();
+  const [selectedChatrooms, setSelectedChatrooms] = useState<{ id: number; isHost: boolean }[]>([]);
+  const [hasHostedChatroom, setHasHostedChatroom] = useState<boolean>(false);
+  const clearSelectedStatus = () => {
+    setSelectedChatrooms([]);
+    setHasHostedChatroom(false);
+  };
+  const { isOpen, openModal, closeModal } = useModal();
+  const { mutate: leaveMultipleChatrooms, isPending } = useLeaveMultipleChatrooms(clearSelectedStatus, closeModal);
+
+  const handleSelectChatroom = (id: number, isHost: boolean) => {
+    setSelectedChatrooms(prev => {
+      const isSelected = prev.some(room => room.id === id);
+      const nextSelected = isSelected ? prev.filter(room => room.id !== id) : [...prev, { id, isHost }];
+
+      setHasHostedChatroom(nextSelected.some(room => room.isHost));
+      return nextSelected;
+    });
+  };
+
+  return (
+    <div className="w-full min-h-screen flex flex-col relative">
+      <ChatroomEditHeader
+        buttonLabel={`${selectedChatrooms.length > 0 ? `${selectedChatrooms.length} ` : ''}선택해제`}
+        disabled={selectedChatrooms.length === 0}
+        onLeftClick={() => navigate('/chat', { state: { viewMode: 'joined' } })}
+        onRightClick={clearSelectedStatus}
+      />
+      <div className="flex-grow pr-5">
+        <JoinedChatroomList
+          isEditMode
+          selectedChatrooms={selectedChatrooms}
+          onClick={(id: number, isHost: boolean) => handleSelectChatroom(id, isHost)}
+        />
+      </div>
+      <div className="p-5 bg-white sticky bottom-0 z-10 border-t border-strokeGray">
+        <ChatActionButton label="채팅방 나가기" disabled={selectedChatrooms.length === 0} onClick={openModal} />
+      </div>
+      {isOpen && (
+        <ModalDimmed onClose={closeModal}>
+          <ConsentModal
+            content={hasHostedChatroom ? HOST_LEAVE_CHATROOM_NOTICE : MEMBER_LEAVE_CHATROOM_NOTICE}
+            leftButtonLabel="나가기"
+            rightButtonLabel="취소"
+            isPending={isPending}
+            onClick={() => {
+              leaveMultipleChatrooms({
+                chatroomsToLeave: selectedChatrooms.map(room => room.id),
+              });
+            }}
+            onClose={closeModal}
+          />
+        </ModalDimmed>
+      )}
+    </div>
+  );
+};
+
+export default JoinedChatroomsEditPage;

--- a/src/pages/JoinedChatroomsEditPage/JoinedChatroomsEditPage.tsx
+++ b/src/pages/JoinedChatroomsEditPage/JoinedChatroomsEditPage.tsx
@@ -1,7 +1,7 @@
 import ChatActionButton from '@/components/button/ChatActionButton';
 import ChatroomEditHeader from '@/components/header/ChatroomEditHeader';
 import { useNavigate } from 'react-router-dom';
-import JoinedChatroomList from '../ChatLobbyPage/components/JoinedChatroomList';
+import JoinedChatroomList from '../../components/chatroom/JoinedChatroomList';
 import { useState } from 'react';
 import useLeaveMultipleChatrooms from '@/hooks/apis/chat/useLeaveMultipleChatrooms';
 import useModal from '@/hooks/useModal';

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -28,7 +28,6 @@ const MainPage = () => {
   return (
     <div className="w-full min-h-screen flex flex-col relative">
       <DateControlHeader headerDate={mainHeaderDate} setHeaderDate={setMainHeaderDate} />
-      zz
       <div className="flex flex-col grow ">
         <PageErrorBoundary>
           <MonthlyContainer />

--- a/src/stories/Button/Button.stories.tsx
+++ b/src/stories/Button/Button.stories.tsx
@@ -108,7 +108,7 @@ function Button() {
 
       <br />
       <h2>DropdownMenu</h2>
-      <GlobalChatroomDropDown closeMenu={() => {}} openModal={() => {}} />
+      <GlobalChatroomDropDown viewMode="all" closeMenu={() => {}} openModal={() => {}} />
       <SingleChatroomDropdown />
       <NoticeDropdown />
 

--- a/src/stories/Button/Button.stories.tsx
+++ b/src/stories/Button/Button.stories.tsx
@@ -100,15 +100,15 @@ function Button() {
 
       <br />
       <h2>ChatroomViewModeToggle</h2>
-      <ChatroomViewModeToggle />
+      <ChatroomViewModeToggle viewMode="all" onClick={() => {}} />
 
       <br />
       <h2>ChatroomSortOptions</h2>
-      <ChatroomSortOptions />
+      <ChatroomSortOptions sortOption="createdAt" onClick={() => {}} />
 
       <br />
       <h2>DropdownMenu</h2>
-      <GlobalChatroomDropDown />
+      <GlobalChatroomDropDown closeMenu={() => {}} openModal={() => {}} />
       <SingleChatroomDropdown />
       <NoticeDropdown />
 

--- a/src/stories/Chatroom/ChatroomItem.stories.tsx
+++ b/src/stories/Chatroom/ChatroomItem.stories.tsx
@@ -7,6 +7,8 @@ function ChatroomItem() {
   return (
     <div>
       <JoinedChatroomItem
+        chatroomId={1}
+        isHost
         chatroomImage={Profile}
         chatroomTitle="나는야 부자될거야"
         lastMessage="오늘은 빗물을 받아 마셨어요"
@@ -14,6 +16,7 @@ function ChatroomItem() {
         lastMessageTime="오후 8:35"
       />
       <JoinedChatroomItem
+        chatroomId={1}
         chatroomImage={Profile}
         isHost
         chatroomTitle="나는야 부자될거야"
@@ -23,6 +26,7 @@ function ChatroomItem() {
         unreadMessageCount={99}
       />
       <JoinedChatroomItem
+        chatroomId={1}
         chatroomImage={Profile}
         isHost
         chatroomTitle="나는야 부자될거야"
@@ -33,6 +37,7 @@ function ChatroomItem() {
         isEditMode
       />
       <PublicChatroomItem
+        chatroomId={1}
         chatroomImage={Profile}
         chatroomTitle="나는야 부자될거야 나는야 부자될거야 나는야 부자될거야 나는야 부자될거야"
         description="부자될사람만 오세요 부자될사람만 오세요 부자될사람만 오세요 부자될사람만 오세요"
@@ -42,6 +47,7 @@ function ChatroomItem() {
         lastMessageTime="30분전"
       />
       <PublicChatroomItem
+        chatroomId={1}
         chatroomImage={Profile}
         chatroomTitle="나는야 부자될거야 나는야 부자될거야 나는야 부자될거야 나는야 부자될거야"
         description="부자될사람만 오세요 부자될사람만 오세요 부자될사람만 오세요 부자될사람만 오세요"

--- a/src/types/chatTypes.ts
+++ b/src/types/chatTypes.ts
@@ -1,0 +1,39 @@
+export type ChatroomViewModeValue = 'all' | 'joined';
+
+export type ChatroomSortOptionValue = 'popularity' | 'createdAt' | 'likes';
+
+export type ChatroomSortParam = 'LIKE' | 'CREATED_AT' | 'POPULARITY';
+
+export type PublicChatroomType = {
+  chatroomId: number;
+  chatroomImage: string;
+  chatroomTitle: string;
+  description: string;
+  hashtags?: string[];
+  currentMemberCount: number;
+  maxMemberCount: number;
+  lastMessageTime: string;
+};
+
+export type JoinedChatroomType = {
+  chatroomId: number;
+  chatroomImage: string;
+  chatroomTitle: string;
+  currentMemberCount: number;
+  lastMessageTime: string;
+  lastMessage?: string;
+  isHost?: boolean;
+  unreadMessageCount?: number | string;
+};
+
+export type AllChatroomsRes = {
+  nextCursor: string;
+  hasNext: boolean;
+  chatrooms: PublicChatroomType[];
+};
+
+export type JoinedChatroomsRes = {
+  nextCursor: string;
+  hasNext: boolean;
+  chatrooms: JoinedChatroomType[];
+};

--- a/src/types/chatTypes.ts
+++ b/src/types/chatTypes.ts
@@ -22,7 +22,7 @@ export type JoinedChatroomType = {
   currentMemberCount: number;
   lastMessageTime: string;
   lastMessage?: string;
-  isHost?: boolean;
+  isHost: boolean;
   unreadMessageCount?: number | string;
 };
 
@@ -36,4 +36,12 @@ export type JoinedChatroomsRes = {
   nextCursor: string;
   hasNext: boolean;
   chatrooms: JoinedChatroomType[];
+};
+
+export type leaveMultipleChatroomsReq = {
+  chatroomsToLeave: number[];
+};
+
+export type leaveMultipleChatroomsRes = {
+  deletedChatroomIds: number[];
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -5,7 +5,7 @@ export type SettingOptionType = {
   externalUrl?: string;
 };
 
-export type TapBarType = 'main' | 'month-week' | 'chart' | 'talk' | 'setting';
+export type TapBarType = 'main' | 'month-week' | 'chart' | 'chat' | 'setting';
 
 export type ModalType = 'logout' | 'dataReset' | 'pwa' | null;
 

--- a/src/utils/chat/timeFormta.ts
+++ b/src/utils/chat/timeFormta.ts
@@ -1,0 +1,29 @@
+import { format, isThisYear, isToday, isYesterday } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+export const formatPublicLastMessageTime = (lastMessageTime: string) => {
+  const now = new Date();
+  const last = new Date(lastMessageTime);
+
+  const diffMs = now.getTime() - last.getTime();
+  const diffMin = Math.floor(diffMs / (1000 * 60));
+
+  if (diffMin <= 10) return '방금 대화';
+  if (diffMin <= 60) return '30분 전';
+  if (diffMin <= 120) return '1시간 전';
+  return null;
+};
+
+export const formatDetailLastMessageTime = (isoString: string) => {
+  const date = new Date(isoString);
+
+  if (isToday(date)) {
+    return format(date, 'a h시 mm분', { locale: ko });
+  }
+
+  if (isYesterday(date)) return '어제';
+
+  if (isThisYear(date)) return format(date, 'M월 d일');
+
+  return format(date, 'yyyy년 M월 d일');
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

#173

## 📝작업 내용

- 전체 채팅방 목록 조회 ( + 필터링 ) : 무한 스크롤
- 참여중인 채팅방 목록 조회 : 무한 스크롤 
- 채팅방 모두 읽음 ( 참여중인 채팅방 )
  - 모두 읽음 요청에 성공한 경우 refetch하지 않고 queryData 의 unreadMessageCount 필드 0으로 초기화
- 참여중인 채팅방 선택 나가기
  - 요청에 성공한 경우 응답 response의 아이디 값들에 해당하는 방들을  queryData에서 삭제 ( filtering )
- MSW 환경 구성
- 채팅방 목록 조회에서 viewMode 간 스크롤 정보를 분리하여 관리해줌