### PR TITLE
Feat: 채팅방 페이지 웹 소켓 실시간 데이터 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import { lazy, Suspense } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Outlet } from 'react-router-dom';
 import './App.css';
 import ProtectedRoute from '@/components/route/ProtectedRoute';
 import RedirectIfLoggedInRoute from '@/components/route/RedirectIfLoggedInRoute';
-import LoadingSpinner from './components/loading/LoadingSpinner';
+import LoadingSpinner from '@/components/loading/LoadingSpinner';
+import ChatSocketProvider from './providers/ChatSocketProvider';
 
 const IDLoginPage = lazy(() => import('@/pages/IDLoginPage/IDLoginPage'));
 const SignupPage = lazy(() => import('@/pages/SignupPage/SignupPage'));
@@ -67,14 +68,21 @@ function App() {
           <Route path="/iteration-data" element={<IterationDataPage />} />
           <Route path="/chart" element={<ChartPage />} />
           <Route path="/chart/category-details/:categoryId" element={<CategoryDetailsPage />} />
-          <Route path="/chat" element={<ChatLobbyPage />} />
           <Route path="/chat/edit" element={<EditJoinedChatroomsPage />} />
           <Route path="/chat/search" element={<SearchChatroomsPage />} />
           <Route path="/chat/hosted" element={<HostedChatroomsPage />} />
           <Route path="/chat/chatroom/add" element={<AddChatroomPage />} />
           <Route path="/chat/chatroom/edit/:chatroomId" element={<EditChatroomPage />} />
           <Route path="/chat/chatroom/cover/:chatroomId" element={<ChatroomCoverPage />} />
-          <Route path="/chat/chatroom/:chatroomId" element={<ChatroomPage />} />
+          <Route
+            element={
+              <ChatSocketProvider>
+                <Outlet />
+              </ChatSocketProvider>
+            }>
+            <Route path="/chat" element={<ChatLobbyPage />} />
+            <Route path="/chat/chatroom/:chatroomId" element={<ChatroomPage />} />
+          </Route>
         </Route>
         <Route path="*" element={<ErrorPage />} />
       </Routes>

--- a/src/components/photo/ProfilePhoto.tsx
+++ b/src/components/photo/ProfilePhoto.tsx
@@ -19,11 +19,8 @@ const ProfilePhoto = ({ photo, rankingType, hideRanking, onClick, className }: P
   })();
 
   return (
-    <button className="relative cursor-pointe" onClick={onClick}>
-      <img
-        src={photo}
-        className={clsx('aspect-square object-cover bg-white border border-strokeGray rounded-xl', className)}
-      />
+    <button className={clsx('relative cursor-pointe', className)} onClick={onClick}>
+      <img src={photo} className={'aspect-square object-cover bg-white border border-strokeGray rounded-xl'} />
       {!hideRanking && <span className="absolute -bottom-2 -right-3">{rankingIcon}</span>}
     </button>
   );

--- a/src/hooks/apis/chat/useGetChatroomMessageInfiniteQuery.ts
+++ b/src/hooks/apis/chat/useGetChatroomMessageInfiniteQuery.ts
@@ -4,7 +4,7 @@ import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
 
 const useGetChatroomMessageInfiniteQuery = (chatroomId: string) => {
   return useInfiniteQuery<ChatRoomMessageRes, Error, InfiniteData<ChatRoomMessageRes>, string[], number | null>({
-    queryKey: ['chatroomMessage', chatroomId],
+    queryKey: ['chatroomMessages', chatroomId],
     queryFn: async ({ pageParam = null }) => await getChatroomMessage(chatroomId, pageParam),
     initialPageParam: null,
     getNextPageParam: lastPage => (lastPage.hasNext ? lastPage.nextCursor : null),

--- a/src/hooks/chat/useChatScroll.ts
+++ b/src/hooks/chat/useChatScroll.ts
@@ -55,7 +55,6 @@ const useChatScroll = ({
     if (!enabled) return;
     if (!didInitialScrollRef.current) return;
     if (isNearBottom()) scrollToBottom('smooth');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, messageDeps);
 
   // 3) 과거 페이지 로드 시 위치 보존

--- a/src/hooks/chat/useMarkMessagesAsRead.ts
+++ b/src/hooks/chat/useMarkMessagesAsRead.ts
@@ -1,0 +1,33 @@
+import { InfiniteData, useQueryClient } from '@tanstack/react-query';
+import { ChatRoomMessageRes } from '@/types/messageType';
+
+const useMarkMessagesAsRead = () => {
+  const queryClient = useQueryClient();
+
+  return (chatroomId: string, readerId: number) => {
+    queryClient.setQueryData(
+      ['chatroomMessages', chatroomId],
+      (oldData: InfiniteData<ChatRoomMessageRes> | undefined) => {
+        if (!oldData) return oldData;
+
+        return {
+          ...oldData,
+          pages: oldData.pages.map(page => ({
+            ...page,
+            messages: page.messages.map(msg => {
+              if (msg.type === 'CHAT_MESSAGE') {
+                return {
+                  ...msg,
+                  unreadBy: msg.unreadBy.filter(id => id !== readerId),
+                };
+              }
+              return msg;
+            }),
+          })),
+        };
+      },
+    );
+  };
+};
+
+export default useMarkMessagesAsRead;

--- a/src/hooks/chat/usePrependMessageToFirstPage.ts
+++ b/src/hooks/chat/usePrependMessageToFirstPage.ts
@@ -1,0 +1,28 @@
+import { InfiniteData, useQueryClient } from '@tanstack/react-query';
+import { ChatMessageUnion, ChatRoomMessageRes } from '@/types/messageType';
+
+export const usePrependMessageToFirstPage = () => {
+  const queryClient = useQueryClient();
+
+  return (chatroomId: string, newMessage: ChatMessageUnion) => {
+    queryClient.setQueryData(
+      ['chatroomMessages', chatroomId],
+      (oldData: InfiniteData<ChatRoomMessageRes> | undefined) => {
+        if (!oldData) return oldData;
+
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page, idx) => {
+            if (idx === 0) {
+              return {
+                ...page,
+                messages: [newMessage, ...page.messages],
+              };
+            }
+            return page;
+          }),
+        };
+      },
+    );
+  };
+};

--- a/src/hooks/chat/useUpdateRecentNoticeInCache.ts
+++ b/src/hooks/chat/useUpdateRecentNoticeInCache.ts
@@ -1,0 +1,20 @@
+import { RecentNoticeType } from '@/types/noticeType';
+import { useQueryClient } from '@tanstack/react-query';
+
+const useUpdateRecentNoticeInCache = () => {
+  const queryClient = useQueryClient();
+
+  return (chatroomId: string, newNotice: RecentNoticeType) => {
+    queryClient.setQueryData(['recentNotice', chatroomId], (oldData: RecentNoticeType | undefined) => {
+      if (!oldData) {
+        return newNotice;
+      }
+      return {
+        ...oldData,
+        ...newNotice,
+      };
+    });
+  };
+};
+
+export default useUpdateRecentNoticeInCache;

--- a/src/hooks/chat/useUpdateUserProfileInCache.ts
+++ b/src/hooks/chat/useUpdateUserProfileInCache.ts
@@ -1,0 +1,32 @@
+import { ChatRoomMessageRes } from '@/types/messageType';
+import { UserProfileType } from '@/types/profileType';
+import { InfiniteData, useQueryClient } from '@tanstack/react-query';
+
+const useUpdateUserProfileInCache = () => {
+  const queryClient = useQueryClient();
+
+  return (chatroomId: string, newUser: UserProfileType) => {
+    queryClient.setQueryData(
+      ['chatroomMessages', chatroomId],
+      (oldData: InfiniteData<ChatRoomMessageRes> | undefined) => {
+        if (!oldData) return oldData;
+
+        return {
+          ...oldData,
+          pages: oldData.pages.map(page => ({
+            ...page,
+            users: {
+              ...page.users,
+              [newUser.userId]: {
+                ...page.users[newUser.userId],
+                ...newUser,
+              },
+            },
+          })),
+        };
+      },
+    );
+  };
+};
+
+export default useUpdateUserProfileInCache;

--- a/src/pages/ChatroomPage/ChatroomPage.tsx
+++ b/src/pages/ChatroomPage/ChatroomPage.tsx
@@ -16,11 +16,13 @@ import ChatActionBox from '@/pages/ChatroomPage/components/ChatActionBox';
 import useChatScroll from '@/hooks/chat/useChatScroll';
 import { StompSubscription } from '@stomp/stompjs';
 import { usePrependMessageToFirstPage } from '@/hooks/chat/usePrependMessageToFirstPage';
+import useMarkMessagesAsRead from '@/hooks/chat/useMarkMessagesAsRead';
 
 const ChatroomPage = () => {
   const navigate = useNavigate();
   const { chatroomId } = useParams();
   const prependMessageToFirstPage = usePrependMessageToFirstPage();
+  const markMessagesAsRead = useMarkMessagesAsRead();
 
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useGetChatroomMessageInfiniteQuery(chatroomId!);
   const { data: chatroomDetails } = useGetChatroomDetails(chatroomId!);
@@ -64,6 +66,8 @@ const ChatroomPage = () => {
           msg.type === 'RANKING_STATUS_MESSAGE'
         ) {
           prependMessageToFirstPage(chatroomId, msg.payload);
+        } else if (msg.type === 'MESSAGE_READ') {
+          markMessagesAsRead(chatroomId, msg.payload.userId);
         }
       });
 

--- a/src/pages/ChatroomPage/ChatroomPage.tsx
+++ b/src/pages/ChatroomPage/ChatroomPage.tsx
@@ -11,13 +11,16 @@ import ChatBody from '@/pages/ChatroomPage/components/message/ChatBody';
 import { UsersMap } from '@/types/messageType';
 // import NoticeSection from '@/pages/ChatroomPage/components/notice/NoticeSection';
 // import useGetRecentNotice from '@/hooks/apis/notice/useGetRecentNotice';
-import { stompClient } from '@/api/stomp';
+import { addOnConnect, stompClient } from '@/api/stomp';
 import ChatActionBox from '@/pages/ChatroomPage/components/ChatActionBox';
 import useChatScroll from '@/hooks/chat/useChatScroll';
+import { StompSubscription } from '@stomp/stompjs';
+import { usePrependMessageToFirstPage } from '@/hooks/chat/usePrependMessageToFirstPage';
 
 const ChatroomPage = () => {
   const navigate = useNavigate();
   const { chatroomId } = useParams();
+  const prependMessageToFirstPage = usePrependMessageToFirstPage();
 
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useGetChatroomMessageInfiniteQuery(chatroomId!);
   const { data: chatroomDetails } = useGetChatroomDetails(chatroomId!);
@@ -43,21 +46,45 @@ const ChatroomPage = () => {
     enabled: true,
   });
 
+  useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
+
   useEffect(() => {
-    stompClient.onConnect = () => {
-      stompClient.subscribe(`/sub/chatroom/${chatroomId}`, message => {
-        console.log('📩 받은 메시지:', message.body);
+    if (!chatroomId) return;
+
+    let sub: StompSubscription | undefined;
+
+    const subscribe = () => {
+      sub = stompClient.subscribe(`/sub/chatroom/${chatroomId}`, message => {
+        const msg = JSON.parse(message.body);
+        console.log(msg);
+        if (
+          msg.type === 'CHAT_MESSAGE' ||
+          msg.type === 'SYSTEM_MESSAGE' ||
+          msg.type === 'RANKING_MESSAGE' ||
+          msg.type === 'RANKING_STATUS_MESSAGE'
+        ) {
+          prependMessageToFirstPage(chatroomId, msg.payload);
+        }
+      });
+
+      stompClient.publish({
+        destination: `/pub/chat/read`,
+        body: JSON.stringify({ chatroomId }),
       });
     };
 
-    stompClient.activate();
+    // 1) 이미 연결돼 있으면 즉시 한 번 실행
+    if (stompClient.connected) subscribe();
 
+    // 2) 앞으로 "연결/재연결"될 때마다 다시 실행하도록 리스너 등록
+    const off = addOnConnect(subscribe);
+
+    // 언마운트 시 정리
     return () => {
-      stompClient.deactivate();
+      off();
+      sub?.unsubscribe();
     };
   }, [chatroomId]);
-
-  useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
 
   return (
     <div className="w-full min-h-screen flex flex-col relative">
@@ -73,7 +100,7 @@ const ChatroomPage = () => {
       />
       <div
         ref={scrollRef}
-        className="w-full relative flex-grow overflow-y-auto h-[calc(100svh-92.3px)] custom-scrollbar">
+        className="w-full relative flex-grow overflow-y-auto h-[calc(100svh-118.3px)] custom-scrollbar">
         {/* {recentNotice && <NoticeSection {...recentNotice} />} */}
         {!isEmpty && hasNextPage && <div ref={observerRef} className="h-4" />}
         {userRole && <ChatBody myUserId={userRole.userId} messages={chatMessages} users={chatroomUsers} />}

--- a/src/pages/ChatroomPage/ChatroomPage.tsx
+++ b/src/pages/ChatroomPage/ChatroomPage.tsx
@@ -17,12 +17,14 @@ import useChatScroll from '@/hooks/chat/useChatScroll';
 import { StompSubscription } from '@stomp/stompjs';
 import { usePrependMessageToFirstPage } from '@/hooks/chat/usePrependMessageToFirstPage';
 import useMarkMessagesAsRead from '@/hooks/chat/useMarkMessagesAsRead';
+import useUpdateUserProfileInCache from '@/hooks/chat/useUpdateUserProfileInCache';
 
 const ChatroomPage = () => {
   const navigate = useNavigate();
   const { chatroomId } = useParams();
   const prependMessageToFirstPage = usePrependMessageToFirstPage();
   const markMessagesAsRead = useMarkMessagesAsRead();
+  const updateUserProfileInCache = useUpdateUserProfileInCache();
 
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useGetChatroomMessageInfiniteQuery(chatroomId!);
   const { data: chatroomDetails } = useGetChatroomDetails(chatroomId!);
@@ -68,6 +70,8 @@ const ChatroomPage = () => {
           prependMessageToFirstPage(chatroomId, msg.payload);
         } else if (msg.type === 'MESSAGE_READ') {
           markMessagesAsRead(chatroomId, msg.payload.userId);
+        } else if (msg.type === 'USER_UPDATED') {
+          updateUserProfileInCache(chatroomId, msg.payload);
         }
       });
 

--- a/src/pages/ChatroomPage/ChatroomPage.tsx
+++ b/src/pages/ChatroomPage/ChatroomPage.tsx
@@ -18,6 +18,7 @@ import { StompSubscription } from '@stomp/stompjs';
 import { usePrependMessageToFirstPage } from '@/hooks/chat/usePrependMessageToFirstPage';
 import useMarkMessagesAsRead from '@/hooks/chat/useMarkMessagesAsRead';
 import useUpdateUserProfileInCache from '@/hooks/chat/useUpdateUserProfileInCache';
+import useUpdateRecentNoticeInCache from '@/hooks/chat/useUpdateRecentNoticeInCache';
 
 const ChatroomPage = () => {
   const navigate = useNavigate();
@@ -25,6 +26,7 @@ const ChatroomPage = () => {
   const prependMessageToFirstPage = usePrependMessageToFirstPage();
   const markMessagesAsRead = useMarkMessagesAsRead();
   const updateUserProfileInCache = useUpdateUserProfileInCache();
+  const updateRecentNoticeInCache = useUpdateRecentNoticeInCache();
 
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useGetChatroomMessageInfiniteQuery(chatroomId!);
   const { data: chatroomDetails } = useGetChatroomDetails(chatroomId!);
@@ -60,7 +62,6 @@ const ChatroomPage = () => {
     const subscribe = () => {
       sub = stompClient.subscribe(`/sub/chatroom/${chatroomId}`, message => {
         const msg = JSON.parse(message.body);
-        console.log(msg);
         if (
           msg.type === 'CHAT_MESSAGE' ||
           msg.type === 'SYSTEM_MESSAGE' ||
@@ -72,6 +73,8 @@ const ChatroomPage = () => {
           markMessagesAsRead(chatroomId, msg.payload.userId);
         } else if (msg.type === 'USER_UPDATED') {
           updateUserProfileInCache(chatroomId, msg.payload);
+        } else if (msg.type === 'NOTICE') {
+          updateRecentNoticeInCache(chatroomId, msg.payload);
         }
       });
 

--- a/src/pages/ChatroomPage/components/ChatActionBox.tsx
+++ b/src/pages/ChatroomPage/components/ChatActionBox.tsx
@@ -26,14 +26,6 @@ const ChatActionBox = ({ chatroomId, isClosed }: Props) => {
     e.target.value = '';
   };
 
-  const handleInput = () => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = 'auto';
-      textarea.style.height = `${textarea.scrollHeight}px`;
-    }
-  };
-
   const handleSendTextMessage = (e: React.FormEvent) => {
     e.preventDefault();
     const text = textareaRef.current?.value;
@@ -50,7 +42,6 @@ const ChatActionBox = ({ chatroomId, isClosed }: Props) => {
 
     if (textareaRef.current) {
       textareaRef.current.value = '';
-      textareaRef.current.style.height = 'auto';
     }
   };
 
@@ -85,10 +76,18 @@ const ChatActionBox = ({ chatroomId, isClosed }: Props) => {
             <textarea
               id="text"
               ref={textareaRef}
-              onInput={handleInput}
-              rows={1}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  if (photoFile) {
+                    handleSendPhotoMessage(e as unknown as React.FormEvent);
+                  } else {
+                    handleSendTextMessage(e as unknown as React.FormEvent);
+                  }
+                }
+              }}
               placeholder="메시지를 입력하세요"
-              className="w-full max-h-[8rem] overflow-y-auto resize-none bg-strokeGray rounded-lg px-3 py-2 outline-none placeholder-defaultGrey custom-scrollbar"
+              className="w-full h-[6rem] overflow-y-auto resize-none bg-lightGray rounded-lg px-3 py-2 outline-none placeholder-defaultGrey custom-scrollbar"
             />
             <div className="h-12 mb-0.5">
               <SubActionButton type="submit" label="전송" />

--- a/src/pages/ChatroomPage/components/message/ChatMessage.tsx
+++ b/src/pages/ChatroomPage/components/message/ChatMessage.tsx
@@ -19,7 +19,7 @@ const ChatMessage = ({ index, message, isMine, rankingType, showTime }: Props) =
   const renderMessageBox = (
     <div
       className={clsx(
-        'relative w-fit rounded-md px-5 py-2 whitespace-pre-line',
+        'relative w-fit rounded-md px-5 py-2 whitespace-pre-line break-all',
         isMine ? 'bg-pastelLime' : 'bg-white border border-strokeGray',
       )}>
       {messageType === 'TEXT' ? content : <img src={content!} alt="chat image" />}

--- a/src/pages/ChatroomPage/components/message/ChatMessageGroup.tsx
+++ b/src/pages/ChatroomPage/components/message/ChatMessageGroup.tsx
@@ -20,7 +20,7 @@ const ChatMessageGroup = ({ messages, isMine, userProfile }: Props) => {
           <ProfilePhoto
             photo={userProfile.profileImage}
             rankingType={userProfile.rankingType}
-            className="w-20"
+            className="w-20 h-20 shrink-0 self-start"
             onClick={() => console.log(userProfile.userId)}
           />
           <div className="flex flex-col items-start gap-1.5">

--- a/src/providers/ChatSocketProvider.tsx
+++ b/src/providers/ChatSocketProvider.tsx
@@ -1,0 +1,13 @@
+import { ReactNode, useEffect } from 'react';
+import { ensureActive, stompClient } from '@/api/stomp';
+
+export default function ChatSocketProvider({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    ensureActive();
+    return () => {
+      stompClient.deactivate();
+    };
+  }, []);
+
+  return <>{children}</>;
+}

--- a/src/types/profileType.ts
+++ b/src/types/profileType.ts
@@ -1,7 +1,7 @@
 export type RankingType = 'SAVER' | 'FLEXER' | 'NONE';
 
 export type UserProfileType = {
-  userId?: number;
+  userId: number;
   profileImage: string;
   nickname: string;
   isHost: boolean;


### PR DESCRIPTION
## #️⃣연관된 이슈

#188

## 📝작업 내용

- 채팅 읽음 요청 발행
- prependMessageToFirstPage : 채팅 메세지, 시스템 메세지,  랭킹 메세지, 랭킹 기능 상태 메세지 구독 처리
- markMessagesAsRead : 채팅 읽음 상태 구독 처리
- updateUserProfileInCache : 채팅 유저 상태 구독 처리
- updateRecentNoticeInCache : 채팅 최근 공지 구독 처리
- 웹 소켓 공통 로직 추가 및 처리 
  - stomp.ts 파일에 웹 소켓 활성화와 onCennect를 위한 유틸 함수 작성
  - ChatSocketProvider를 통해 웹 소켓을 사용하는 페이지 렌더링 시 active 및 deactivate 처리