### PR TITLE
Hotfix: 채팅관련 오류사항 수정

### DIFF
--- a/src/api/services/chatService.ts
+++ b/src/api/services/chatService.ts
@@ -163,5 +163,5 @@ export const delegateChatroomHost = async (chatroomId: string, body: DelegateCha
     endpoints.chat.delegateChatroomHost(chatroomId),
     body,
   );
-  return res.data;
+  return res;
 };

--- a/src/components/button/ChatroomSortOptions.tsx
+++ b/src/components/button/ChatroomSortOptions.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const ChatroomSortOptions = ({ sortOption, onClick }: Props) => {
   const options: { label: '최근 대화순' | '최근 생성순' | '좋아요순'; value: ChatroomSortOptionValue }[] = [
-    { label: '최근 대화순', value: 'popularity' },
+    { label: '최근 대화순', value: 'updatedAt' },
     { label: '최근 생성순', value: 'createdAt' },
     { label: '좋아요순', value: 'likes' },
   ];

--- a/src/components/photo/ProfilePhoto.tsx
+++ b/src/components/photo/ProfilePhoto.tsx
@@ -19,7 +19,7 @@ const ProfilePhoto = ({ photo, rankingType, hideRanking, onClick, className }: P
   })();
 
   return (
-    <button className={clsx('relative cursor-pointe', className)} onClick={onClick}>
+    <button className={clsx('relative cursor-pointer', className)} onClick={onClick}>
       <img src={photo} className={'aspect-square object-cover bg-white border border-strokeGray rounded-xl'} />
       {!hideRanking && <span className="absolute -bottom-2 -right-3">{rankingIcon}</span>}
     </button>

--- a/src/hooks/apis/chat/useAllChatroomsInfiniteQuery.ts
+++ b/src/hooks/apis/chat/useAllChatroomsInfiniteQuery.ts
@@ -5,7 +5,7 @@ import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
 const useAllChatroomsInfiniteQuery = (option: ChatroomSortOptionValue) => {
   const mapSortOptionToParam = (option: ChatroomSortOptionValue): ChatroomSortParam => {
     const map = {
-      popularity: 'POPULARITY',
+      updatedAt: 'UPDATED_AT',
       createdAt: 'CREATED_AT',
       likes: 'LIKE',
     } as const;

--- a/src/hooks/apis/chat/useDelegateChatroomHost.ts
+++ b/src/hooks/apis/chat/useDelegateChatroomHost.ts
@@ -1,11 +1,17 @@
 import { delegateChatroomHost } from '@/api/services/chatService';
 import { DelegateChatroomHostReq } from '@/types/chatTypes';
 import { useMutation } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
 
-const useDelegateChatroomHost = (chatroomId: string, closeModal: () => void) => {
+const useDelegateChatroomHost = (chatroomId: string) => {
+  const navigate = useNavigate();
   return useMutation({
     mutationFn: (body: DelegateChatroomHostReq) => delegateChatroomHost(chatroomId, body),
-    onSuccess: () => closeModal(),
+    onSuccess: data => {
+      toast.success(data.message);
+      navigate(-1);
+    },
   });
 };
 

--- a/src/hooks/apis/chat/useGetChatroomMessageInfiniteQuery.ts
+++ b/src/hooks/apis/chat/useGetChatroomMessageInfiniteQuery.ts
@@ -9,7 +9,6 @@ const useGetChatroomMessageInfiniteQuery = (chatroomId: string) => {
     initialPageParam: null,
     getNextPageParam: lastPage => (lastPage.hasNext ? lastPage.nextCursor : null),
     placeholderData: prevData => prevData,
-    staleTime: Infinity,
   });
 };
 

--- a/src/hooks/apis/chat/useLeaveChatroom.ts
+++ b/src/hooks/apis/chat/useLeaveChatroom.ts
@@ -6,7 +6,7 @@ const useLeaveChatroom = () => {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: leaveChatroom,
-    onSuccess: () => navigate(-1),
+    onSuccess: () => navigate('/chat'),
   });
 };
 

--- a/src/hooks/chat/useChatScroll.ts
+++ b/src/hooks/chat/useChatScroll.ts
@@ -18,11 +18,12 @@ const useChatScroll = ({
   isFetchingNextPage = false,
   followThreshold = 150,
 }: Options) => {
-  const el = scrollRef.current;
   const didInitialScrollRef = useRef(false);
   const prevHeightRef = useRef(0);
 
   const isNearBottom = (offset = followThreshold) => {
+    const el = scrollRef.current;
+
     if (!el) return true;
     return el.scrollHeight - el.scrollTop - el.clientHeight <= offset;
   };
@@ -31,6 +32,7 @@ const useChatScroll = ({
   useLayoutEffect(() => {
     if (!pages || didInitialScrollRef.current) return;
 
+    const el = scrollRef.current;
     const total = pages?.reduce((acc, p) => acc + (p.messages?.length ?? 0), 0) ?? 0;
 
     if (total > 0 && el) {
@@ -66,6 +68,8 @@ const useChatScroll = ({
   }, [isFetchingNextPage]);
 
   useEffect(() => {
+    const el = scrollRef.current;
+
     if (!isFetchingNextPage) {
       if (el && prevHeightRef.current) {
         const diff = el.scrollHeight - prevHeightRef.current;

--- a/src/hooks/chat/usePrependMessageToFirstPage.ts
+++ b/src/hooks/chat/usePrependMessageToFirstPage.ts
@@ -1,5 +1,6 @@
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { ChatMessageUnion, ChatRoomMessageRes } from '@/types/messageType';
+import { ChatroomDetailsRes } from '@/types/chatTypes';
 
 export const usePrependMessageToFirstPage = () => {
   const queryClient = useQueryClient();
@@ -24,5 +25,20 @@ export const usePrependMessageToFirstPage = () => {
         };
       },
     );
+
+    queryClient.setQueryData(['chatroomDetails', chatroomId], (oldData: ChatroomDetailsRes) => {
+      if (!oldData) return oldData;
+
+      let newCurrentMemberCount = oldData.currentMemberCount;
+      if (newMessage.type === 'SYSTEM_MESSAGE') {
+        if (newMessage.messageType === 'ENTER') newCurrentMemberCount += 1;
+        else if (newMessage.messageType === 'LEAVE' || newMessage.messageType === 'DELEGATE')
+          newCurrentMemberCount = oldData.currentMemberCount -= 1;
+      }
+      return {
+        ...oldData,
+        currentMemberCount: newCurrentMemberCount,
+      };
+    });
   };
 };

--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,12 @@
     border-color: #e6e6e6;
     border-radius: 10px;
   }
+
+  .custom-scrollbar {
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    -webkit-overflow-scrolling: touch;
+  }
 }
 
 @layer components {

--- a/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
+++ b/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
@@ -20,7 +20,7 @@ import { useNavigate } from 'react-router-dom';
 const ChatLobbyPage = () => {
   const navigate = useNavigate();
   const [viewMode, setViewMode] = useState<ChatroomViewModeValue>('all');
-  const [sortOption, setSortOption] = useState<ChatroomSortOptionValue>('popularity');
+  const [sortOption, setSortOption] = useState<ChatroomSortOptionValue>('updatedAt');
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const { isOpen, openModal, closeModal } = useModal();
   const dropdownRef = useRef<HTMLDivElement>(null);

--- a/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
+++ b/src/pages/ChatLobbyPage/ChatLobbyPage.tsx
@@ -23,9 +23,11 @@ const ChatLobbyPage = () => {
   const [sortOption, setSortOption] = useState<ChatroomSortOptionValue>('updatedAt');
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const { isOpen, openModal, closeModal } = useModal();
+
   const dropdownRef = useRef<HTMLDivElement>(null);
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
   const scrollPositions = useRef<{ all: number; joined: number }>({ all: 0, joined: 0 });
+
   useClickOutside({
     refs: [dropdownRef, settingsButtonRef],
     onClickOutside: () => setIsMenuOpen(false),
@@ -37,9 +39,16 @@ const ChatLobbyPage = () => {
     sessionStorage.setItem('viewMode', next);
   };
 
+  const handleSortOptionChange = (next: ChatroomSortOptionValue) => {
+    setSortOption(next);
+    sessionStorage.setItem('sortOption', next);
+  };
+
   useEffect(() => {
-    const storagedViewMode = sessionStorage.getItem('viewMode') ?? 'all';
-    setViewMode(storagedViewMode as ChatroomViewModeValue);
+    const storageViewMode = sessionStorage.getItem('viewMode') ?? 'all';
+    const storageSortOption = sessionStorage.getItem('sortOption') ?? 'updatedAt';
+    setViewMode(storageViewMode as ChatroomViewModeValue);
+    setSortOption(storageSortOption as ChatroomSortOptionValue);
   }, []);
 
   useEffect(() => {
@@ -83,7 +92,7 @@ const ChatLobbyPage = () => {
             <>
               <ChatroomSortOptions
                 sortOption={sortOption}
-                onClick={(value: ChatroomSortOptionValue) => setSortOption(value)}
+                onClick={(option: ChatroomSortOptionValue) => handleSortOptionChange(option)}
               />
               <AllChatroomsList sortOption={sortOption} />
             </>

--- a/src/pages/ChatroomCoverPage/ChatroomCoverPage.tsx
+++ b/src/pages/ChatroomCoverPage/ChatroomCoverPage.tsx
@@ -23,10 +23,14 @@ const ChatroomCoverPage = () => {
   const { mutate: enterChatroom, isPending: isEnterPending } = useEnterChatroom(chatroomId!);
 
   const handleEnterChatroom = () => {
-    if (chatroomCover?.hasPassword) {
-      openModal();
+    if (chatroomCover?.isJoined) {
+      navigate(`/chat/chatroom/${chatroomId}`);
     } else {
-      enterChatroom({ chatroomPassword: null });
+      if (chatroomCover?.hasPassword) {
+        openModal();
+      } else {
+        enterChatroom({ chatroomPassword: null });
+      }
     }
   };
 

--- a/src/pages/ChatroomDetailPage/ChatroomDetailPage.tsx
+++ b/src/pages/ChatroomDetailPage/ChatroomDetailPage.tsx
@@ -2,7 +2,7 @@ import ChatroomDetailHeader from '@/components/header/ChatroomDetailHeader';
 import PhotoPreviewBox from '@/pages/ChatroomDetailPage/components/PhotoPreviewBox';
 import { useParams } from 'react-router-dom';
 import NoticePreviewBox from '@/pages/ChatroomDetailPage/components/NoticePreviewBox';
-import RankingPreviewBox from '@/pages/ChatroomDetailPage/components/RankingPreviewBox';
+// import RankingPreviewBox from '@/pages/ChatroomDetailPage/components/RankingPreviewBox';
 import ChatMemberBox from '@/pages/ChatroomDetailPage/components/ChatMemberBox';
 import ChatActionButton from '@/components/button/ChatActionButton';
 import ChatroomProfileBox from '@/pages/ChatroomDetailPage/components/ChatroomProfileBox';
@@ -33,7 +33,7 @@ const ChatroomDetailPage = () => {
             <ChatroomProfileBox chatroomId={chatroomId} />
             <PhotoPreviewBox chatroomId={chatroomId} />
             <NoticePreviewBox chatroomId={chatroomId} />
-            <RankingPreviewBox chatroomId={chatroomId} />
+            {/* <RankingPreviewBox chatroomId={chatroomId} /> */}
             <ChatMemberBox chatroomId={chatroomId} />
             <div className="w-full mt-3">
               <ChatActionButton label={'채팅방 나가기'} onClick={openModal} />

--- a/src/pages/ChatroomHostDelegatePage/components/DelegateUserItem.tsx
+++ b/src/pages/ChatroomHostDelegatePage/components/DelegateUserItem.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 const DelegateUserItem = ({ chatroomId, userProfile }: Props) => {
   const { isOpen, openModal, closeModal } = useModal();
-  const { mutate: delegateHost } = useDelegateChatroomHost(chatroomId, closeModal);
+  const { mutate: delegateHost } = useDelegateChatroomHost(chatroomId);
 
   const handleClick = () => {
     delegateHost({

--- a/src/pages/ChatroomPage/ChatroomPage.tsx
+++ b/src/pages/ChatroomPage/ChatroomPage.tsx
@@ -72,7 +72,7 @@ const ChatroomPage = () => {
           prependMessageToFirstPage(chatroomId, msg.payload);
         } else if (msg.type === 'MESSAGE_READ') {
           markMessagesAsRead(chatroomId, msg.payload.userId);
-        } else if (msg.type === 'USER_UPDATED') {
+        } else if (msg.type === 'USER_UPDATED' || msg.type === 'USER_JOINED') {
           updateUserProfileInCache(chatroomId, msg.payload);
         } else if (msg.type === 'NOTICE') {
           updateRecentNoticeInCache(chatroomId, msg.payload);

--- a/src/pages/ChatroomPage/ChatroomPage.tsx
+++ b/src/pages/ChatroomPage/ChatroomPage.tsx
@@ -49,7 +49,6 @@ const ChatroomPage = () => {
     messageDeps: [chatMessages],
     isFetchingNextPage,
     followThreshold: 150,
-    enabled: true,
   });
 
   useInfiniteScroll({ observerRef, hasNextPage, isFetchingNextPage, fetchNextPage });
@@ -119,7 +118,7 @@ const ChatroomPage = () => {
           <ChatBody chatroomId={chatroomId} myUserId={userRole.userId} messages={chatMessages} users={chatroomUsers} />
         )}
       </div>
-      <ChatActionBox chatroomId={Number(chatroomId)} isClosed={chatroomDetails?.isClosed} />
+      <ChatActionBox chatroomId={Number(chatroomId)} isClosed={chatroomDetails?.isClosed} scrollRef={scrollRef} />
     </div>
   );
 };

--- a/src/pages/ChatroomPage/components/ChatActionBox.tsx
+++ b/src/pages/ChatroomPage/components/ChatActionBox.tsx
@@ -3,15 +3,17 @@ import ImageUploadButton from '@/components/button/icon/ImageUploadButton';
 import XIconButton from '@/components/button/icon/XIconButton';
 import SubActionButton from '@/components/button/SubActionButton';
 import useUploadChatroomPhoto from '@/hooks/apis/photo/useUploadChatroomPhoto';
+import { scrollToBottom } from '@/utils/chat/scrollToBottom';
 import { createFormData } from '@/utils/form/createFormData';
-import { useRef, useState } from 'react';
+import { MutableRefObject, useRef, useState } from 'react';
 
 interface Props {
   chatroomId: number;
   isClosed?: boolean;
+  scrollRef: MutableRefObject<HTMLDivElement | null>;
 }
 
-const ChatActionBox = ({ chatroomId, isClosed }: Props) => {
+const ChatActionBox = ({ chatroomId, isClosed, scrollRef }: Props) => {
   const [photoFile, setPhotoFile] = useState<File | null>(null);
   const [isComposing, setIsComposing] = useState<boolean>(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -40,6 +42,8 @@ const ChatActionBox = ({ chatroomId, isClosed }: Props) => {
         content: text,
       }),
     });
+
+    scrollToBottom(scrollRef, 'instant');
 
     if (textareaRef.current) {
       textareaRef.current.value = '';

--- a/src/pages/ChatroomPage/components/ChatActionBox.tsx
+++ b/src/pages/ChatroomPage/components/ChatActionBox.tsx
@@ -13,6 +13,7 @@ interface Props {
 
 const ChatActionBox = ({ chatroomId, isClosed }: Props) => {
   const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [isComposing, setIsComposing] = useState<boolean>(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { mutate: uploadChatroomPhoto } = useUploadChatroomPhoto(String(chatroomId), setPhotoFile);
 
@@ -66,7 +67,7 @@ const ChatActionBox = ({ chatroomId, isClosed }: Props) => {
       )}
       <form
         className="flex items-end w-full p-2.5 bg-white border-t border-strokeGray gap-2.5"
-        onSubmit={photoFile ? handleSendPhotoMessage : handleSendTextMessage}>
+        onSubmit={e => e.preventDefault()}>
         {isClosed ? (
           <p className="w-full h-12 mb-0.5 flex items-center justify-center">대화할 수 없는 상태입니다.</p>
         ) : (
@@ -75,8 +76,10 @@ const ChatActionBox = ({ chatroomId, isClosed }: Props) => {
             <textarea
               id="text"
               ref={textareaRef}
+              onCompositionStart={() => setIsComposing(true)}
+              onCompositionEnd={() => setIsComposing(false)}
               onKeyDown={e => {
-                if (e.key === 'Enter' && !e.shiftKey) {
+                if (e.key === 'Enter' && !e.shiftKey && !isComposing) {
                   e.preventDefault();
                   if (photoFile) {
                     handleSendPhotoMessage(e as unknown as React.FormEvent);
@@ -89,7 +92,7 @@ const ChatActionBox = ({ chatroomId, isClosed }: Props) => {
               className="w-full h-[6rem] overflow-y-auto resize-none bg-lightGray rounded-lg px-3 py-2 outline-none placeholder-defaultGrey custom-scrollbar"
             />
             <div className="h-12 mb-0.5">
-              <SubActionButton type="submit" label="전송" />
+              <SubActionButton label="전송" onClick={photoFile ? handleSendPhotoMessage : handleSendTextMessage} />
             </div>
           </>
         )}

--- a/src/pages/ChatroomPage/components/ChatActionBox.tsx
+++ b/src/pages/ChatroomPage/components/ChatActionBox.tsx
@@ -10,7 +10,7 @@ import { MutableRefObject, useRef, useState } from 'react';
 interface Props {
   chatroomId: number;
   isClosed?: boolean;
-  scrollRef: MutableRefObject<HTMLDivElement | null>;
+  scrollRef?: MutableRefObject<HTMLDivElement | null>;
 }
 
 const ChatActionBox = ({ chatroomId, isClosed, scrollRef }: Props) => {
@@ -43,7 +43,7 @@ const ChatActionBox = ({ chatroomId, isClosed, scrollRef }: Props) => {
       }),
     });
 
-    scrollToBottom(scrollRef, 'instant');
+    if (scrollRef) scrollToBottom(scrollRef, 'instant');
 
     if (textareaRef.current) {
       textareaRef.current.value = '';

--- a/src/pages/ChatroomPage/components/message/ChatBody.tsx
+++ b/src/pages/ChatroomPage/components/message/ChatBody.tsx
@@ -17,7 +17,7 @@ const ChatBody = ({ chatroomId, messages, myUserId, users }: Props) => {
   const groupedMessages = groupChatMessages(messages);
 
   return (
-    <div className="flex flex-col items-center gap-10 p-5">
+    <div className="flex flex-col items-center gap-10 p-5 w-full">
       {groupedMessages.map(group => {
         if (group.type === 'GROUP') {
           const user = users[group.senderId];

--- a/src/pages/ChatroomPage/components/message/ChatBody.tsx
+++ b/src/pages/ChatroomPage/components/message/ChatBody.tsx
@@ -17,7 +17,7 @@ const ChatBody = ({ chatroomId, messages, myUserId, users }: Props) => {
   const groupedMessages = groupChatMessages(messages);
 
   return (
-    <div className="flex flex-col items-center gap-10 p-5 w-full">
+    <div className="flex flex-col items-center gap-7 p-5 w-full">
       {groupedMessages.map(group => {
         if (group.type === 'GROUP') {
           const user = users[group.senderId];

--- a/src/pages/ChatroomPage/components/message/ChatMessage.tsx
+++ b/src/pages/ChatroomPage/components/message/ChatMessage.tsx
@@ -19,7 +19,7 @@ const ChatMessage = ({ index, message, isMine, rankingType, showTime }: Props) =
   const renderMessageBox = (
     <div
       className={clsx(
-        'flex justify-center relative w-fit rounded-md whitespace-pre-line break-all',
+        'flex justify-center relative w-fit max-w-[75%] rounded-md whitespace-pre-line break-all',
         messageType === 'TEXT' && 'px-5 py-2 ',
         isMine ? 'bg-pastelLime' : 'bg-white border border-strokeGray',
       )}>
@@ -38,7 +38,7 @@ const ChatMessage = ({ index, message, isMine, rankingType, showTime }: Props) =
   );
 
   return (
-    <div className={clsx('flex items-end gap-2.5', isMine ? 'justify-end' : 'justify-start')}>
+    <div className={clsx('flex items-end gap-2.5 w-full', isMine ? 'justify-end' : 'justify-start')}>
       {!isMine && renderMessageBox}
       <div className={clsx('flex flex-col', isMine ? 'items-end' : 'items-start')}>
         {unreadBy.length > 0 && <p className="text-sm">{unreadBy.length}</p>}

--- a/src/pages/ChatroomPage/components/message/ChatMessage.tsx
+++ b/src/pages/ChatroomPage/components/message/ChatMessage.tsx
@@ -24,7 +24,7 @@ const ChatMessage = ({ index, message, isMine, rankingType, showTime }: Props) =
         isMine ? 'bg-pastelLime' : 'bg-white border border-strokeGray',
       )}>
       {messageType === 'TEXT' ? (
-        content
+        <p className="whitespace-pre-wrap">{content}</p>
       ) : (
         <img src={content!} alt="chat image" className="w-fit aspect-auto object-contain rounded-md" />
       )}

--- a/src/pages/ChatroomPage/components/message/ChatMessageGroup.tsx
+++ b/src/pages/ChatroomPage/components/message/ChatMessageGroup.tsx
@@ -20,14 +20,14 @@ const ChatMessageGroup = ({ chatroomId, messages, isMine, userProfile }: Props) 
   return (
     <div className="flex flex-col w-full">
       {!isMine && userProfile && (
-        <div className="flex gap-5 items-start">
+        <div className="flex gap-5 items-start w-full">
           <ProfilePhoto
             photo={userProfile.profileImage}
             rankingType={userProfile.rankingType}
             className="w-20 h-20 shrink-0 self-start cursor-pointer"
             onClick={() => openModal()}
           />
-          <div className="flex flex-col items-start gap-1.5">
+          <div className="flex flex-col items-start gap-1.5 w-full">
             <div className="flex items-center gap-2">
               <p>{userProfile.nickname}</p>
               {userProfile.isHost && <CrownIcon size={20} />}

--- a/src/pages/ChatroomPage/components/message/SystemMessage.tsx
+++ b/src/pages/ChatroomPage/components/message/SystemMessage.tsx
@@ -1,7 +1,12 @@
 import { SystemMessageType } from '@/types/messageType';
+import { format } from 'date-fns';
 
-const SystemMessage = ({ content }: SystemMessageType) => {
-  return <div className="w-fit bg-strokeGray text-md text-white text-center rounded-4xl px-10 py-1.5">{content}</div>;
+const SystemMessage = ({ content, messageType }: SystemMessageType) => {
+  return (
+    <div className="w-fit bg-strokeGray text-md text-white text-center rounded-4xl px-10 py-1.5">
+      {messageType === 'DATE' ? format(new Date(content), 'yyyy년 MM월 dd일') : content}
+    </div>
+  );
 };
 
 export default SystemMessage;

--- a/src/pages/ChatroomPage/components/message/SystemMessage.tsx
+++ b/src/pages/ChatroomPage/components/message/SystemMessage.tsx
@@ -1,10 +1,11 @@
 import { SystemMessageType } from '@/types/messageType';
 import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 
 const SystemMessage = ({ content, messageType }: SystemMessageType) => {
   return (
     <div className="w-fit bg-strokeGray text-md text-white text-center rounded-4xl px-10 py-1.5">
-      {messageType === 'DATE' ? format(new Date(content), 'yyyy년 MM월 dd일') : content}
+      {messageType === 'DATE' ? format(new Date(content), 'yyyy년 MM월 dd일 EEEE', { locale: ko }) : content}
     </div>
   );
 };

--- a/src/pages/EditChatroomPage/components/EditChatroomForm.tsx
+++ b/src/pages/EditChatroomPage/components/EditChatroomForm.tsx
@@ -25,7 +25,13 @@ const EditChatroomForm = () => {
   };
 
   useEffect(() => {
-    if (chatroomData) reset(chatroomData);
+    if (chatroomData) {
+      reset({
+        ...chatroomData,
+        chatroomImage: chatroomData.chatroomImage ?? undefined,
+        chatroomPassword: chatroomData.chatroomPassword ?? '',
+      });
+    }
   }, [reset, chatroomData]);
 
   return (

--- a/src/types/chatTypes.ts
+++ b/src/types/chatTypes.ts
@@ -4,9 +4,9 @@ import { UserProfileType } from './profileType';
 
 export type ChatroomViewModeValue = 'all' | 'joined';
 
-export type ChatroomSortOptionValue = 'popularity' | 'createdAt' | 'likes';
+export type ChatroomSortOptionValue = 'updatedAt' | 'createdAt' | 'likes';
 
-export type ChatroomSortParam = 'LIKE' | 'CREATED_AT' | 'POPULARITY';
+export type ChatroomSortParam = 'LIKE' | 'CREATED_AT' | 'UPDATED_AT';
 
 export type PublicChatroomType = {
   chatroomId: number;

--- a/src/types/messageType.ts
+++ b/src/types/messageType.ts
@@ -8,7 +8,7 @@ export type ChatMessageType = {
   messageId: number;
   chatroomId: number;
   senderId: number;
-  messageType: 'TEXT' | 'IMAGE';
+  messageType: 'TEXT' | 'PHOTO';
   content: string;
   sentAt: string;
   unreadBy: number[];

--- a/src/utils/chat/scrollToBottom.ts
+++ b/src/utils/chat/scrollToBottom.ts
@@ -1,0 +1,10 @@
+import { MutableRefObject } from 'react';
+
+export const scrollToBottom = (
+  scrollRef: MutableRefObject<HTMLDivElement | null>,
+  behavior: ScrollBehavior = 'auto',
+) => {
+  const el = scrollRef.current;
+  if (!el) return;
+  el.scrollTo({ top: el.scrollHeight, behavior });
+};

--- a/src/utils/chat/waitForImages.ts
+++ b/src/utils/chat/waitForImages.ts
@@ -1,0 +1,18 @@
+export const waitForImages = (container: HTMLElement) => {
+  const images = Array.from(container.querySelectorAll('img')).filter(img => !img.complete);
+
+  if (images.length === 0) return Promise.resolve();
+
+  return new Promise<void>(resolve => {
+    let loaded = 0;
+    const checkDone = () => {
+      loaded++;
+      if (loaded === images.length) resolve();
+    };
+
+    images.forEach(img => {
+      img.addEventListener('load', checkDone, { once: true });
+      img.addEventListener('error', checkDone, { once: true });
+    });
+  });
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

#198

## 📝작업 내용

### < 채팅방 입장,퇴장 관련 요구사항 >

- 채팅방 정보조회 => currentMemberCount 필드값 갱신
- 이전 채팅 메세지 조회 users 필드 값 갱신 => 유저 상태 구독 처리

### < 채팅메세지 입력 관련 오류 >

- 채팅메세지 공백도 표시되도록 수정
- 맥북 채팅 관련 오류 수정 ( 마지막 글자가 한번 더 보내지는 오류)
=> MacOS 한글 IME: compositionend 직후 Enter keydown → input 이벤트 순서가 달라서 같은 글자가 두 번 들어올 수 있음
=> isComposing 상태를 두고, compositionend가 끝나야만 Enter 전송 허용하는 방식 적용

### < 채팅방 스크롤 관련 오류 >

- 사용자가 채팅 입력하면 하단으로 스크롤 복귀하는 로직 추가
- 모바일에서 무한 스크롤 부자연스러움 문제 원인 파악
- 사진 메세지 스크롤 하단 복귀가 잘 안되는 오류 수정

### <채팅방 편집 페이지 오류>

- 채팅방 편집 버튼 활성화 오류
