### PR TITLE
Feat: 추가된 요구사항 처리

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -94,6 +94,7 @@ export const endpoints = {
     getChatroomDetails: (chatroomId: string) => `/chatrooms/${chatroomId}/details`,
     getChatroomUserRole: (chatroomId: string) => `/chatrooms/${chatroomId}/role`,
     kickUser: (chatroomId: string, userId: number) => `/chatrooms/${chatroomId}/members/${userId}`,
+    kickUserReadMessage: (chatroomId: string) => `/chatrooms/${chatroomId}/block-users/read`,
     reportChatroomMember: (chatroomId: string, userId: number) => `/chatrooms/${chatroomId}/members/${userId}/reports`,
     getAllChatroomMembers: (chatroomId: string) => `/chatrooms/${chatroomId}/members/all`,
     searchChatroomMembers: (chatroomId: string, nickname: string) =>

--- a/src/api/services/chatService.ts
+++ b/src/api/services/chatService.ts
@@ -132,6 +132,11 @@ export const kickUser = async (chatroomId: string, userId: number) => {
   return res.data;
 };
 
+export const kickUserMessageRead = async (chatroomId: string) => {
+  const res = await fetchData<undefined>('DELETE', endpoints.chat.kickUserReadMessage(chatroomId));
+  return res.data;
+};
+
 export const reportChatroomMember = async (chatroomId: string, userId: number, body: ReportChatroomMemberReq) => {
   const res = await fetchData<ReportChatroomMemberReq, ReportChatroomMemberRes>(
     'POST',

--- a/src/components/chatroom/JoinedChatroomList.tsx
+++ b/src/components/chatroom/JoinedChatroomList.tsx
@@ -63,7 +63,13 @@ const JoinedChatroomList = ({ isEditMode, selectedChatrooms, handleSelectChatroo
             onClick={() => {
               if (isEditMode && handleSelectChatroom) handleSelectChatroom(chatroom.chatroomId, chatroom.isHost);
               else {
-                navigate(`/chat/chatroom/${chatroom.chatroomId}`);
+                navigate(
+                  `/chat/chatroom/${chatroom.chatroomId}${
+                    chatroom.latestReadMessageId && (chatroom.unreadMessageCount ?? 0) > 10
+                      ? `?latestReadMessageId=${chatroom.latestReadMessageId}`
+                      : ''
+                  }`,
+                );
                 handleEnterChatroom(chatroom.chatroomId);
               }
             }}

--- a/src/components/chatroom/chat/JoinedChatroomItem.tsx
+++ b/src/components/chatroom/chat/JoinedChatroomItem.tsx
@@ -39,7 +39,7 @@ const JoinedChatroomItem = ({
                 <span className="text-defaultGrey whitespace-nowrap">{currentMemberCount}</span>
               </div>
             </div>
-            <p className="text-md text-defaultGrey truncate min-w-0 whitespace-nowrap">{lastMessage}</p>
+            <p className="text-md text-defaultGrey truncate min-w-0 min-h-[21px] whitespace-nowrap">{lastMessage}</p>
           </div>
         </div>
         <div className="flex flex-col items-end justify-start gap-1.5 shrink-0">

--- a/src/hooks/apis/chat/useGetChatroomMessageInfiniteQuery.ts
+++ b/src/hooks/apis/chat/useGetChatroomMessageInfiniteQuery.ts
@@ -9,6 +9,7 @@ const useGetChatroomMessageInfiniteQuery = (chatroomId: string) => {
     initialPageParam: null,
     getNextPageParam: lastPage => (lastPage.hasNext ? lastPage.nextCursor : null),
     staleTime: 0,
+    gcTime: 0,
   });
 };
 

--- a/src/hooks/apis/chat/useKickUserMessageRead.ts
+++ b/src/hooks/apis/chat/useKickUserMessageRead.ts
@@ -1,0 +1,35 @@
+import { kickUserMessageRead } from '@/api/services/chatService';
+import { joinedChatroomsQueryKey } from '@/constants/queryKeys';
+import useMarkMessagesAsRead from '@/hooks/chat/useMarkMessagesAsRead';
+import { JoinedChatroomsRes } from '@/types/chatTypes';
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+
+const useKickUserMessageRead = (chatroomId: string, userId?: number) => {
+  const markMessagesAsRead = useMarkMessagesAsRead();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => kickUserMessageRead(chatroomId),
+    onSuccess: () => {
+      if (chatroomId && userId) {
+        markMessagesAsRead(chatroomId, userId);
+      }
+
+      queryClient.setQueryData(joinedChatroomsQueryKey, (oldData: InfiniteData<JoinedChatroomsRes> | undefined) => {
+        if (!oldData) return oldData;
+
+        return {
+          ...oldData,
+          pages: oldData.pages.map(page => ({
+            ...page,
+            chatrooms: page.chatrooms.map(chatroom =>
+              chatroom.chatroomId === Number(chatroomId) ? { ...chatroom, unreadMessageCount: 0 } : chatroom,
+            ),
+          })),
+        };
+      });
+    },
+  });
+};
+
+export default useKickUserMessageRead;

--- a/src/hooks/chat/useChatroomSubscription.ts
+++ b/src/hooks/chat/useChatroomSubscription.ts
@@ -3,17 +3,18 @@ import { addOnConnect, stompClient } from '@/api/stomp';
 import { StompSubscription } from '@stomp/stompjs';
 import { IMessage } from '@stomp/stompjs';
 import { useHandleChatMessage } from '@/hooks/chat/useHandleChatMessage';
+import { ChatroomUserRoleRes } from '@/types/chatTypes';
 
 export const useChatroomSubscription = (
   chatroomId: string,
-  userId: number | undefined,
+  userRole: ChatroomUserRoleRes | undefined,
   setIsChatDisabled: React.Dispatch<React.SetStateAction<boolean>>,
   onReadMessage: (userId: number) => void,
 ) => {
-  const handleMessage = useHandleChatMessage(chatroomId, setIsChatDisabled, onReadMessage, userId);
+  const handleMessage = useHandleChatMessage(chatroomId, setIsChatDisabled, onReadMessage, userRole?.userId);
 
   useEffect(() => {
-    if (!chatroomId || !userId) return;
+    if (!chatroomId || !userRole || userRole.chatroomRole === 'BANNED') return;
 
     let sub: StompSubscription | undefined;
 
@@ -40,5 +41,5 @@ export const useChatroomSubscription = (
       off();
       sub?.unsubscribe();
     };
-  }, [chatroomId, userId, handleMessage, setIsChatDisabled]);
+  }, [chatroomId, userRole, handleMessage, setIsChatDisabled]);
 };

--- a/src/hooks/chat/useMarkMessagesAsRead.ts
+++ b/src/hooks/chat/useMarkMessagesAsRead.ts
@@ -4,29 +4,29 @@ import { ChatRoomMessageRes } from '@/types/messageType';
 const useMarkMessagesAsRead = () => {
   const queryClient = useQueryClient();
 
-  return (chatroomId: string, readerId: number) => {
+  return (chatroomId: string, readerId: number, latestReadMessageId?: string | null) => {
     queryClient.setQueryData(
       ['chatroomMessages', chatroomId],
       (oldData: InfiniteData<ChatRoomMessageRes> | undefined) => {
         if (!oldData) return oldData;
 
-        const newData = {
+        return {
           ...oldData,
           pages: oldData.pages.map(page => ({
             ...page,
             messages: page.messages.map(msg => {
               if (msg.type === 'CHAT_MESSAGE') {
-                return {
-                  ...msg,
-                  unreadBy: msg.unreadBy.filter(id => id !== readerId),
-                };
+                if (!latestReadMessageId || msg.messageId <= Number(latestReadMessageId)) {
+                  return {
+                    ...msg,
+                    unreadBy: msg.unreadBy.filter(id => id !== readerId),
+                  };
+                }
               }
               return msg;
             }),
           })),
         };
-
-        return newData;
       },
     );
   };

--- a/src/pages/ChatroomPage/components/message/ChatBody.tsx
+++ b/src/pages/ChatroomPage/components/message/ChatBody.tsx
@@ -11,10 +11,11 @@ interface Props {
   messages: ChatMessageUnion[];
   myUserId: number;
   users: Record<string, UserProfileType>;
+  latestReadMessageId?: string | null;
 }
 
-const ChatBody = ({ chatroomId, messages, myUserId, users }: Props) => {
-  const groupedMessages = groupChatMessages(messages);
+const ChatBody = ({ chatroomId, messages, myUserId, users, latestReadMessageId }: Props) => {
+  const groupedMessages = groupChatMessages(messages, latestReadMessageId);
 
   return (
     <div className="flex flex-col items-center gap-7 p-5 w-full">

--- a/src/pages/ChatroomPage/components/message/ChatMessage.tsx
+++ b/src/pages/ChatroomPage/components/message/ChatMessage.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 const ChatMessage = ({ index, message, isMine, rankingType, showTime }: Props) => {
   const { chatroomId } = useParams();
-  const { messageType, content, sentAt, unreadBy } = message;
+  const { messageType, content, sentAt, unreadBy, messageId } = message;
   const { isOpen, openModal, closeModal } = useModal();
 
   const renderMessageBox = (
@@ -48,7 +48,9 @@ const ChatMessage = ({ index, message, isMine, rankingType, showTime }: Props) =
   );
 
   return (
-    <div className={clsx('flex items-end gap-2.5 w-full', isMine ? 'justify-end' : 'justify-start')}>
+    <div
+      data-message-id={messageId}
+      className={clsx('flex items-end gap-2.5 w-full', isMine ? 'justify-end' : 'justify-start')}>
       {!isMine && renderMessageBox}
       <div className={clsx('flex flex-col', isMine ? 'items-end' : 'items-start')}>
         {unreadBy.length > 0 && <p className="text-sm">{unreadBy.length}</p>}

--- a/src/pages/ChatroomPage/components/message/SystemMessage.tsx
+++ b/src/pages/ChatroomPage/components/message/SystemMessage.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const SystemMessage = ({ myUserId, message }: Props) => {
-  const { messageType, content, userId } = message;
+  const { messageType, content, userId } = message!;
 
   let displayContent = content;
 

--- a/src/pages/ChatroomPage/components/modal/UserProfileModal.tsx
+++ b/src/pages/ChatroomPage/components/modal/UserProfileModal.tsx
@@ -50,10 +50,12 @@ const UserProfileModal = ({ chatroomId, userProfile, closeModal }: Props) => {
             <p className="text-white">{userProfile.nickname}</p>
           </div>
           <Divider weight={1.5} />
-          <div className="flex gap-5 mb-30">
-            {userRole?.chatroomRole === 'HOST' && <UtilityButton label="내보내기" onClick={openKickUserModal} />}
-            <UtilityButton label="신고하기" onClick={openReportModal} />
-          </div>
+          {userProfile.nickname !== '알 수 없음' && (
+            <div className="flex gap-5 mb-30">
+              {userRole?.chatroomRole === 'HOST' && <UtilityButton label="내보내기" onClick={openKickUserModal} />}
+              <UtilityButton label="신고하기" onClick={openReportModal} />
+            </div>
+          )}
         </div>
       </div>
       {isUserProfileImageModal && (

--- a/src/types/chatTypes.ts
+++ b/src/types/chatTypes.ts
@@ -26,7 +26,7 @@ export type JoinedChatroomType = {
   currentMemberCount: number;
   lastMessageTime: string;
   lastMessage?: string;
-  latestReadMessageId: number | null;
+  latestReadMessageId?: number | null;
   isHost: boolean;
   unreadMessageCount?: number;
 };

--- a/src/types/chatTypes.ts
+++ b/src/types/chatTypes.ts
@@ -26,6 +26,7 @@ export type JoinedChatroomType = {
   currentMemberCount: number;
   lastMessageTime: string;
   lastMessage?: string;
+  latestReadMessageId: number | null;
   isHost: boolean;
   unreadMessageCount?: number;
 };

--- a/src/types/messageType.ts
+++ b/src/types/messageType.ts
@@ -27,13 +27,13 @@ export type ChatMessageType = TextChatMessage | PhotoChatMessage;
 export type SystemMessageCategory = 'ENTER' | 'LEAVE' | 'DELEGATE' | 'KICK' | 'DATE' | 'CLOSE';
 
 export type SystemMessageType = {
-  type: 'SYSTEM_MESSAGE';
+  type?: 'SYSTEM_MESSAGE';
   userId?: number;
-  messageId: number;
-  chatroomId: number;
-  messageType: SystemMessageCategory;
+  messageId?: number;
+  chatroomId?: number;
+  messageType?: SystemMessageCategory;
   content: string;
-  sentAt: string;
+  sentAt?: string;
 };
 
 export type RankingType = 'SAVER' | 'FLEXER' | 'NONE';

--- a/src/utils/chat/groupMessages.ts
+++ b/src/utils/chat/groupMessages.ts
@@ -22,7 +22,7 @@ function minuteKeyOf(ts: string | number | Date) {
   return `${yyyy}-${mm}-${dd} ${HH}:${MM}`;
 }
 
-export function groupChatMessages(messages: ChatMessageUnion[]): GroupedMessage[] {
+export function groupChatMessages(messages: ChatMessageUnion[], latestReadMessageId?: string | null): GroupedMessage[] {
   const result: GroupedMessage[] = [];
   let buffer: ChatMessageType[] = [];
   let bufferSenderId: number | null = null;
@@ -60,6 +60,11 @@ export function groupChatMessages(messages: ChatMessageUnion[]): GroupedMessage[
         buffer = [msg];
         bufferSenderId = msg.senderId;
         bufferMinuteKey = mk;
+      }
+
+      if (latestReadMessageId && msg.messageId === Number(latestReadMessageId)) {
+        flushBuffer();
+        result.push({ type: 'SYSTEM_MESSAGE', message: { content: '여기까지 읽으셨습니다.' } });
       }
     } else {
       flushBuffer();


### PR DESCRIPTION
## #️⃣연관된 이슈

#216

## 📝작업 내용

- 회원탈퇴 된 유저 프로필 조회 시 신고하기/내보내기 버튼 안 보이게 처리
- 강제 퇴장 당한 사용자 채팅 읽음 처리 api 및 웹 소켓 연결 끊기 처리
- lastReadMessageId 값 관련된 로직 추가
    - 참여중인 채팅방 ⇒ 채팅방 페이지 이동 시 마지막  읽은 메세지에서부터 조회 가능하도록 수정
    - 채팅방 읽음 브로드캐스트로 인한 채팅 메세지 갱신 로직에 lastReadMessageId 값까지만 갱신하도록 로직 수정
