### PR TITLE
Refactor: 프로필/채팅 UI 개선 및 소셜 로그인 플로우 Step 추가

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -12,6 +12,7 @@ export const endpoints = {
     getUserDetails: '/user/detail',
     getOnboardingUserDetails: '/user/oauth/profile',
     updateOnboardingUserDetails: '/user/oauth/profile',
+    revertOnboardingUserDetails: '/user/kakao/revert',
     updateUserDetails: '/user/update',
     updatePassword: '/user/password',
     dataReset: '/user/reset',

--- a/src/api/services/authService.ts
+++ b/src/api/services/authService.ts
@@ -131,6 +131,11 @@ export const updateOnboardingUserDetails = async (body: FormData) => {
   return res;
 };
 
+export const revertOnboardingUserDetails = async () => {
+  const res = await fetchData<undefined>('PATCH', endpoints.auth.revertOnboardingUserDetails);
+  return res;
+};
+
 export const getUserRole = async () => {
   const res = await fetchData<undefined, UserRoleType>('GET', endpoints.auth.getUserRole);
   if (res.data) return res.data.role;

--- a/src/components/route/ProtectedRoute.tsx
+++ b/src/components/route/ProtectedRoute.tsx
@@ -15,8 +15,8 @@ const ProtectedRoute = () => {
 
   const isOnboardingRoute = location.pathname === '/onboarding/profile';
 
-  if (userRole === 'PENDING' && !isOnboardingRoute) {
-    return <Navigate to="/onboarding/profile" replace />;
+  if ((userRole === 'USER' || userRole === 'KAKAO_EXISTING_USER_PENDING') && !isOnboardingRoute) {
+    return <Navigate to="/onboarding/profile" state={{ userRole: userRole }} replace />;
   }
 
   return <Outlet />;

--- a/src/constants/modal.tsx
+++ b/src/constants/modal.tsx
@@ -31,3 +31,8 @@ export const rankingDescriptions = [
     <span className="text-sunsetRose">(후보 인원이 2명 미만인 경우에는 랭킹 제공 X)</span>
   </>,
 ];
+
+export const ACCOUNT_MERGE_CONFIRM = `같은 이메일로 가입된 계정이 있습니다. 
+기존 계정과 통합하시겠습니까? 
+통합을 원하지 않는 경우 기존 계정을 탈퇴한 뒤 다시 가입해주세요.
+`;

--- a/src/hooks/apis/auth/useRevertOnboardingUserDetails.ts
+++ b/src/hooks/apis/auth/useRevertOnboardingUserDetails.ts
@@ -1,0 +1,8 @@
+import { revertOnboardingUserDetails } from '@/api/services/authService';
+import { useMutation } from '@tanstack/react-query';
+
+const useRevertOnboardingUserDetails = (handleModalClose: () => void) => {
+  return useMutation({ mutationFn: revertOnboardingUserDetails, onSuccess: handleModalClose });
+};
+
+export default useRevertOnboardingUserDetails;

--- a/src/pages/ChatroomPage/components/ChatActionBox.tsx
+++ b/src/pages/ChatroomPage/components/ChatActionBox.tsx
@@ -77,7 +77,12 @@ const ChatActionBox = ({ chatroomId, isChatDisabled, scrollRef }: Props) => {
 
     if (textareaRef.current) {
       textareaRef.current.value = '';
-      textareaRef.current.focus();
+      textareaRef.current.style.height = 'auto';
+
+      // 🔹 모바일 placeholder 잘림 방지
+      textareaRef.current.style.display = 'none';
+      void textareaRef.current.offsetHeight;
+      textareaRef.current.style.display = '';
     }
   };
 
@@ -126,7 +131,13 @@ const ChatActionBox = ({ chatroomId, isChatDisabled, scrollRef }: Props) => {
 
             <textarea
               id="text"
+              rows={1}
               ref={textareaRef}
+              onInput={e => {
+                const el = e.currentTarget;
+                el.style.height = 'auto';
+                el.style.height = `${Math.min(el.scrollHeight, 96)}px`;
+              }}
               onKeyDown={e => {
                 const isMobile = /Mobi|Android|iPhone/i.test(navigator.userAgent);
 
@@ -140,7 +151,7 @@ const ChatActionBox = ({ chatroomId, isChatDisabled, scrollRef }: Props) => {
                 }
               }}
               placeholder="메시지를 입력하세요"
-              className="w-full min-h-[3rem] max-h-[6rem] overflow-y-auto resize-none bg-lightGray rounded-lg px-3 py-2 outline-none placeholder-defaultGrey custom-scrollbar"
+              className="w-full max-h-[6rem] overflow-y-auto resize-none bg-lightGray rounded-lg px-3 py-2 outline-none placeholder-defaultGrey custom-scrollbar"
             />
 
             <div className="h-12 mb-0.5">

--- a/src/pages/ChatroomPage/components/modal/UserProfileModal.tsx
+++ b/src/pages/ChatroomPage/components/modal/UserProfileModal.tsx
@@ -37,6 +37,8 @@ const UserProfileModal = ({ chatroomId, userProfile, closeModal }: Props) => {
     closeReportModal,
   );
 
+  const isMine = userRole?.userId === userProfile.userId;
+
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-stretch justify-center">
       <div className="w-[500px] h-full flex justify-center items-end bg-defaultGrey relative">
@@ -54,7 +56,7 @@ const UserProfileModal = ({ chatroomId, userProfile, closeModal }: Props) => {
           <Divider weight={1.5} />
 
           <div className="flex gap-5 mb-30">
-            {userProfile.nickname !== '알 수 없음' && (
+            {userProfile.nickname !== '알 수 없음' && !isMine && (
               <>
                 {userRole?.chatroomRole === 'HOST' && <UtilityButton label="내보내기" onClick={openKickUserModal} />}
                 <UtilityButton label="신고하기" onClick={openReportModal} />

--- a/src/pages/ProfileOnboardingPage/ProfileOnboardingPage.tsx
+++ b/src/pages/ProfileOnboardingPage/ProfileOnboardingPage.tsx
@@ -6,30 +6,58 @@ import { ProfileFormData } from '@/types/authTypes';
 import { zodResolver } from '@hookform/resolvers/zod';
 import LeftArrowButton from '@/components/button/icon/LeftArrowButton';
 import useLogout from '@/hooks/apis/auth/useLogout';
+import { useLocation } from 'react-router-dom';
+import ConsentModal from '@/components/modal/chat/ConsentModal';
+import ModalDimmed from '@/components/modal/ModalDimmed';
+import { useState } from 'react';
+import { ACCOUNT_MERGE_CONFIRM } from '@/constants/modal';
+import useRevertOnboardingUserDetails from '@/hooks/apis/auth/useRevertOnboardingUserDetails';
 
 const ProfileOnboardingPage = () => {
+  const { state } = useLocation();
+  const isMergeRequired = state.userRole === 'KAKAO_EXISTING_USER_PENDING';
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(isMergeRequired);
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+  };
+
   const { mutate: logout } = useLogout();
+  const { mutate: revertUserDetails } = useRevertOnboardingUserDetails(handleModalClose);
   const methods = useForm<ProfileFormData>({
     resolver: zodResolver(profileSchema),
     mode: 'onChange',
   });
 
   return (
-    <div className="flex flex-col w-full min-h-screen">
-      <DefaultHeader
-        leftButton={
-          <LeftArrowButton
-            onClick={() => {
-              logout();
-            }}
+    <>
+      <div className="flex flex-col w-full min-h-screen">
+        <DefaultHeader
+          leftButton={
+            <LeftArrowButton
+              onClick={() => {
+                logout();
+              }}
+            />
+          }
+          label="회원정보 입력"
+        />
+        <FormProvider {...methods}>
+          <OnboardingProfileForm />
+        </FormProvider>
+      </div>
+      {isModalOpen && (
+        <ModalDimmed>
+          <ConsentModal
+            leftButtonLabel="예"
+            rightButtonLabel="아니요"
+            content={ACCOUNT_MERGE_CONFIRM}
+            onClick={() => setIsModalOpen(false)}
+            onClose={revertUserDetails}
           />
-        }
-        label="회원정보 입력"
-      />
-      <FormProvider {...methods}>
-        <OnboardingProfileForm />
-      </FormProvider>
-    </div>
+        </ModalDimmed>
+      )}
+    </>
   );
 };
 

--- a/src/types/authTypes.ts
+++ b/src/types/authTypes.ts
@@ -41,7 +41,7 @@ export const emailPurposeList = ['register', 'changeEmail', 'findUsername', 'cha
 export type EmailPurposeType = (typeof emailPurposeList)[number];
 
 export type UserRoleType = {
-  role: 'USER' | 'ADMIN' | 'TEST' | 'PENDING';
+  role: 'USER' | 'ADMIN' | 'TEST' | 'PENDING' | 'KAKAO_EXISTING_USER_PENDING';
 };
 
 export type SendEmailReq = { email: string; purpose: EmailPurposeType; username?: string };


### PR DESCRIPTION
## #️⃣연관된 이슈

#240

## 📝작업 내용

- 프로필 페이지
  - 내 프로필일 경우 내보내기/신고하기 버튼 노출 안되게 수정
- 채팅 입력창
  - 채팅 전송 후 placeHolder 잘리는 오류 수정
  - textArea 기본 높이 한줄 ⇒ 입력 줄이 늘어날 때 높이가 늘어나도록
  - 이미지 아이콘 눌렀을 때 키보드 내려가는 오류 수정 => 웹에서는 파일 인풋 열릴 때 textArea에 focus유지 불가능
- 카카오 로그인 기존 계정과 통합 여부 묻는 Step 추가
