### PR TITLE
Hotfix: 카카오 가입 철회 API 엔드포인트 오류 수정 및 success 로직 수정

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -12,7 +12,7 @@ export const endpoints = {
     getUserDetails: '/user/detail',
     getOnboardingUserDetails: '/user/oauth/profile',
     updateOnboardingUserDetails: '/user/oauth/profile',
-    revertOnboardingUserDetails: '/user/kakao/revert',
+    revertOnboardingUserDetails: '/auth/kakao/revert',
     updateUserDetails: '/user/update',
     updatePassword: '/user/password',
     dataReset: '/user/reset',

--- a/src/hooks/apis/auth/useRevertOnboardingUserDetails.ts
+++ b/src/hooks/apis/auth/useRevertOnboardingUserDetails.ts
@@ -1,8 +1,8 @@
 import { revertOnboardingUserDetails } from '@/api/services/authService';
 import { useMutation } from '@tanstack/react-query';
 
-const useRevertOnboardingUserDetails = (handleModalClose: () => void) => {
-  return useMutation({ mutationFn: revertOnboardingUserDetails, onSuccess: handleModalClose });
+const useRevertOnboardingUserDetails = (handleAuthRevert: () => void) => {
+  return useMutation({ mutationFn: revertOnboardingUserDetails, onSuccess: handleAuthRevert });
 };
 
 export default useRevertOnboardingUserDetails;

--- a/src/pages/ProfileOnboardingPage/ProfileOnboardingPage.tsx
+++ b/src/pages/ProfileOnboardingPage/ProfileOnboardingPage.tsx
@@ -18,12 +18,8 @@ const ProfileOnboardingPage = () => {
   const isMergeRequired = state.userRole === 'KAKAO_EXISTING_USER_PENDING';
   const [isModalOpen, setIsModalOpen] = useState<boolean>(isMergeRequired);
 
-  const handleModalClose = () => {
-    setIsModalOpen(false);
-  };
-
   const { mutate: logout } = useLogout();
-  const { mutate: revertUserDetails } = useRevertOnboardingUserDetails(handleModalClose);
+  const { mutate: revertUserDetails } = useRevertOnboardingUserDetails(logout);
   const methods = useForm<ProfileFormData>({
     resolver: zodResolver(profileSchema),
     mode: 'onChange',


### PR DESCRIPTION
## #️⃣연관된 이슈

#240

## 📝작업 내용

- 카카오 가입 철회 API 엔드포인트 오류 수정 및 success 로직 수정